### PR TITLE
feat: support app-selected Agent Core skills

### DIFF
--- a/apps/tui/package.json
+++ b/apps/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felan-ai/felan",
-  "version": "0.1.0-alpha.0",
+  "version": "0.1.0-alpha.1",
   "description": "Local Felan terminal agent",
   "license": "MIT",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "felan",
-  "version": "0.1.0-alpha.0",
+  "version": "0.1.0-alpha.1",
   "private": true,
   "description": "Portable Felan agent core, extensions, and local TUI",
   "license": "MIT",

--- a/packages/agent-core/README.md
+++ b/packages/agent-core/README.md
@@ -27,3 +27,7 @@ inactive session, while `createAgentCoreSessionRuntimeFactory` provides the
 typed seam used with Pi's `createAgentSessionRuntime`. Applications retain
 ownership of model credentials, settings, session storage, stream wrappers,
 child-session creation, and presentation listeners.
+
+Applications may pass an explicit `skills` list into session composition.
+Agent Core exposes only that list while project, user, and package skill
+discovery remain disabled.

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felan-ai/agent-core",
-  "version": "0.1.0-alpha.0",
+  "version": "0.1.0-alpha.1",
   "description": "Portable Felan agent contracts and composition",
   "license": "MIT",
   "type": "module",

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -58,5 +58,6 @@ export type {
   LoadExtensionsResult,
   ResourceLoader,
   SessionStartEvent,
+  Skill,
   ToolDefinition,
 } from '@earendil-works/pi-coding-agent';

--- a/packages/agent-core/src/resource-loader.ts
+++ b/packages/agent-core/src/resource-loader.ts
@@ -3,6 +3,7 @@ import {
   SettingsManager,
   type InlineExtension,
   type ResourceLoader,
+  type Skill,
 } from '@earendil-works/pi-coding-agent';
 
 export interface CreateAgentCoreResourceLoaderOptions {
@@ -10,6 +11,7 @@ export interface CreateAgentCoreResourceLoaderOptions {
   readonly agentDir: string;
   readonly extensionFactories: readonly InlineExtension[];
   readonly extensionFlagValues?: ReadonlyMap<string, boolean | string>;
+  readonly skills?: readonly Skill[];
   readonly systemPrompt?: string;
   readonly appendSystemPrompt?: readonly string[];
 }
@@ -17,6 +19,7 @@ export interface CreateAgentCoreResourceLoaderOptions {
 export async function createAgentCoreResourceLoader(
   options: CreateAgentCoreResourceLoaderOptions,
 ): Promise<ResourceLoader> {
+  const skills = options.skills === undefined ? undefined : [...options.skills];
   const resourceSettings = SettingsManager.inMemory({
     packages: [],
     extensions: [],
@@ -38,6 +41,14 @@ export async function createAgentCoreResourceLoader(
     noPromptTemplates: true,
     noThemes: true,
     noContextFiles: true,
+    ...(skills === undefined
+      ? {}
+      : {
+          skillsOverride: () => ({
+            skills,
+            diagnostics: [],
+          }),
+        }),
     ...(options.systemPrompt === undefined ? {} : { systemPrompt: options.systemPrompt }),
     ...(options.appendSystemPrompt === undefined
       ? {}

--- a/packages/agent-core/src/session.ts
+++ b/packages/agent-core/src/session.ts
@@ -10,6 +10,7 @@ import {
   type SessionManager,
   type SessionStartEvent,
   type SettingsManager,
+  type Skill,
   type ToolDefinition,
 } from '@earendil-works/pi-coding-agent';
 import { loadFelanExtensions, type ExtensionPackageImporter } from './extensions.js';
@@ -60,6 +61,7 @@ export interface CreateAgentCoreSessionOptions {
   readonly scopedModels?: CreateAgentSessionOptions['scopedModels'];
   readonly sessionStartEvent?: SessionStartEvent;
   readonly customTools?: readonly ToolDefinition[];
+  readonly skills?: readonly Skill[];
   readonly systemPrompt?: string;
   readonly appendSystemPrompt?: readonly string[];
 }
@@ -127,6 +129,7 @@ async function composeAgentCoreSession(
     ...(options.extensionFlagValues === undefined
       ? {}
       : { extensionFlagValues: options.extensionFlagValues }),
+    ...(options.skills === undefined ? {} : { skills: options.skills }),
     ...(options.systemPrompt === undefined ? {} : { systemPrompt: options.systemPrompt }),
     ...(options.appendSystemPrompt === undefined
       ? {}

--- a/packages/agent-core/test/resource-loader.test.ts
+++ b/packages/agent-core/test/resource-loader.test.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import type { Skill } from '@earendil-works/pi-coding-agent';
 import { afterEach, describe, expect, it } from 'vitest';
 import { createAgentCoreResourceLoader } from '../src/index.js';
 
@@ -51,6 +52,37 @@ describe('Agent Core resource loading', () => {
         },
       }],
     })).rejects.toThrow('<inline:@felan-ai/broken>: initialization failed');
+  });
+
+  it('uses only app-supplied skills while ambient discovery stays disabled', async () => {
+    const root = await temporaryDirectory();
+    const cwd = join(root, 'workspace');
+    const agentDir = join(root, 'agent-dir');
+    await mkdir(cwd, { recursive: true });
+    await writeFile(join(cwd, 'SKILL.md'), '---\nname: ambient\ndescription: Ambient\n---\n');
+    const skillPath = join(root, 'selected', 'SKILL.md');
+    const selected: Skill = {
+      name: 'selected',
+      description: 'Selected by the application',
+      filePath: skillPath,
+      baseDir: join(root, 'selected'),
+      sourceInfo: {
+        path: skillPath,
+        source: 'app:selected',
+        scope: 'temporary',
+        origin: 'top-level',
+      },
+      disableModelInvocation: false,
+    };
+
+    const loader = await createAgentCoreResourceLoader({
+      cwd,
+      agentDir,
+      extensionFactories: [],
+      skills: [selected],
+    });
+
+    expect(loader.getSkills()).toEqual({ skills: [selected], diagnostics: [] });
   });
 });
 

--- a/packages/ext-context/package.json
+++ b/packages/ext-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felan-ai/ext-context",
-  "version": "0.1.0-alpha.0",
+  "version": "0.1.0-alpha.1",
   "description": "Progressive-context extension for Felan",
   "license": "MIT",
   "type": "module",

--- a/packages/ext-powerline/package.json
+++ b/packages/ext-powerline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felan-ai/ext-powerline",
-  "version": "0.1.0-alpha.0",
+  "version": "0.1.0-alpha.1",
   "description": "Terminal powerline extension for Felan",
   "license": "MIT",
   "type": "module",

--- a/packages/ext-prewalk/package.json
+++ b/packages/ext-prewalk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felan-ai/ext-prewalk",
-  "version": "0.1.0-alpha.0",
+  "version": "0.1.0-alpha.1",
   "description": "Prewalk extension for Felan",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- accept an explicit application-selected skill list in Agent Core session composition
- keep project, user, package, and ambient skill discovery disabled
- release the fixed public package group as `0.1.0-alpha.1`

## Verification
- `nvm exec 22.20.0 pnpm verify`
- 20 Agent Core tests passed
- all five public package tarballs packed successfully