### PR TITLE
feat: add local Felan agent and portable extensions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,17 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm verify
+      - run: pnpm check:proposed-version
       - run: npm install --global npm@11.19.0
       - run: test "${GITHUB_REF_NAME#v}" = "$(node -p 'require("./package.json").version')"
       - run: |
-          for package in .artifacts/*.tgz; do
+          version="$(node -p 'require("./package.json").version')"
+          for package in \
+            ".artifacts/felan-ai-agent-core-${version}.tgz" \
+            ".artifacts/felan-ai-ext-context-${version}.tgz" \
+            ".artifacts/felan-ai-ext-prewalk-${version}.tgz" \
+            ".artifacts/felan-ai-ext-powerline-${version}.tgz" \
+            ".artifacts/felan-ai-felan-${version}.tgz"
+          do
             npm publish "$package" --access public --tag next --provenance
           done

--- a/NOTICE
+++ b/NOTICE
@@ -9,3 +9,8 @@ with their respective authors.
 mslavov/pi-extensions at commit 7e72e509fe45a5a87c4c2e176cb711de994a8c1d.
 Copyright (c) 2026 Dimitar Panayotov and Milko Slavov. Package-level attribution
 and license terms are included in packages/ext-prewalk/NOTICE and LICENSE.
+
+@felan-ai/ext-powerline contains code adapted from the MIT-licensed
+pi-powerline source by Milko Slavov. The source credits the MIT-licensed
+marckrenn/pi-sub packages/sub-core for subscription provider and usage logic;
+Felan excludes its credential loading and subscription network implementation.

--- a/NOTICE
+++ b/NOTICE
@@ -4,3 +4,8 @@ Copyright (c) 2026 Felan contributors
 This product includes software developed by the Pi project and other open
 source projects listed in the package lockfile. Their license terms remain
 with their respective authors.
+
+@felan-ai/ext-prewalk adapts MIT-licensed portions of packages/pi-prewalk from
+mslavov/pi-extensions at commit 7e72e509fe45a5a87c4c2e176cb711de994a8c1d.
+Copyright (c) 2026 Dimitar Panayotov and Milko Slavov. Package-level attribution
+and license terms are included in packages/ext-prewalk/NOTICE and LICENSE.

--- a/README.md
+++ b/README.md
@@ -6,14 +6,13 @@ shared agent core, first-party Pi extensions, and local terminal application.
 ## Packages
 
 - `@felan-ai/agent-core`: portable runtime contracts, Node.js host runtime, and runtime test kit
-- `@felan-ai/ext-context`: progressive-context extension package
+- `@felan-ai/ext-context`: runtime-portable progressive loading of nested project instructions
 - `@felan-ai/ext-prewalk`: prewalk extension package
 - `@felan-ai/ext-powerline`: terminal powerline extension package
 - `@felan-ai/felan`: account-free local terminal application with the `felan` binary
 
 The local terminal application composes the host runtime and source-controlled
-extension set around Agent Core. The extension packages retain their current
-implementations while their dedicated stories progress.
+extension set around Agent Core.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@ shared agent core, first-party Pi extensions, and local terminal application.
 - `@felan-ai/agent-core`: portable runtime contracts, Node.js host runtime, and runtime test kit
 - `@felan-ai/ext-context`: runtime-portable progressive loading of nested project instructions
 - `@felan-ai/ext-prewalk`: prewalk extension package
-- `@felan-ai/ext-powerline`: terminal powerline extension package
+- `@felan-ai/ext-powerline`: ANSI-aware local TUI footer with cached Git, model, session, context, and extension status segments
 - `@felan-ai/felan`: account-free local terminal application with the `felan` binary
 
 The local terminal application composes the host runtime and source-controlled
-extension set around Agent Core.
+extension set around Agent Core. `@felan-ai/ext-powerline` is enabled by default
+only in the local TUI and remains inert in headless modes.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@ shared agent core, first-party Pi extensions, and local terminal application.
 - `@felan-ai/ext-context`: progressive-context extension package
 - `@felan-ai/ext-prewalk`: prewalk extension package
 - `@felan-ai/ext-powerline`: terminal powerline extension package
-- `@felan-ai/felan`: local terminal application package
+- `@felan-ai/felan`: account-free local terminal application with the `felan` binary
 
-The extension and terminal packages are compile-safe foundations for their
-respective implementation stories.
+The local terminal application composes the host runtime and source-controlled
+extension set around Agent Core. The extension packages retain their current
+implementations while their dedicated stories progress.
 
 ## Requirements
 
@@ -26,6 +27,10 @@ corepack enable
 pnpm install
 pnpm verify
 ```
+
+After installation, run `felan` for the interactive local agent or
+`felan --diagnostics` for runtime versions. Local model credentials are managed
+through the TUI and do not require a Felan account.
 
 See [Contributing](CONTRIBUTING.md) and [Release process](docs/releasing.md).
 

--- a/apps/tui/README.md
+++ b/apps/tui/README.md
@@ -1,3 +1,32 @@
 # @felan-ai/felan
 
-Package foundation for the local Felan terminal application.
+Local, account-free Felan terminal agent built on `@felan-ai/agent-core` and
+Pi's interactive TUI.
+
+```sh
+npx @felan-ai/felan
+```
+
+The package exposes the `felan` binary. It stores model credentials, settings,
+and sessions under `~/.felan/agent` by default; set `FELAN_AGENT_DIR` to select
+another local directory. Use `/login` inside the TUI to configure provider-owned
+model credentials without a Felan account.
+
+Each session uses a cwd-bound `HostAgentRuntime`. Pi's session runtime recreates
+the host runtime, filtered settings, resources, and session composition for
+new, resume, fork, clone, and import flows, then rebinds the active interactive
+UI. Host mode uses the current user's filesystem and process permissions and is
+not an isolation boundary.
+
+Only the source-controlled Felan extension package list is imported. Ambient Pi
+packages, extensions, skills, prompts, themes, and context files remain filtered;
+inline Felan extensions can still provide shared tools, prompts, interaction,
+and subagent behavior. Agent Core's `spawn_agent` tool delegates child creation
+through the portable host contract; local children run as in-process Agent Core
+sessions on fresh host runtimes without Felan cloud services.
+
+```sh
+felan --diagnostics
+```
+
+Diagnostics include the Felan, Agent Core, Pi, and Node.js versions.

--- a/apps/tui/README.md
+++ b/apps/tui/README.md
@@ -21,7 +21,9 @@ not an isolation boundary.
 Only the source-controlled Felan extension package list is imported. Ambient Pi
 packages, extensions, skills, prompts, themes, and context files remain filtered;
 inline Felan extensions can still provide shared tools, prompts, interaction,
-and subagent behavior. Agent Core's `spawn_agent` tool delegates child creation
+and subagent behavior. The default local list includes `@felan-ai/ext-powerline`
+for an ANSI-aware footer; it is a direct TUI dependency and is not part of any
+cloud composition. Agent Core's `spawn_agent` tool delegates child creation
 through the portable host contract; local children run as in-process Agent Core
 sessions on fresh host runtimes without Felan cloud services.
 

--- a/apps/tui/package.json
+++ b/apps/tui/package.json
@@ -13,6 +13,9 @@
     "LICENSE",
     "README.md"
   ],
+  "bin": {
+    "felan": "./dist/cli.js"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -26,6 +29,7 @@
     "prepack": "pnpm build"
   },
   "dependencies": {
+    "@earendil-works/pi-coding-agent": "0.82.1",
     "@felan-ai/agent-core": "workspace:*",
     "@felan-ai/ext-context": "workspace:*",
     "@felan-ai/ext-powerline": "workspace:*",

--- a/apps/tui/package.json
+++ b/apps/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felan-ai/felan",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "description": "Local Felan terminal agent",
   "license": "MIT",
   "type": "module",

--- a/apps/tui/src/application.ts
+++ b/apps/tui/src/application.ts
@@ -1,0 +1,22 @@
+import { InteractiveMode } from '@earendil-works/pi-coding-agent';
+import { createLocalFelanRuntime, type CreateLocalFelanRuntimeOptions } from './runtime.js';
+
+export interface RunLocalFelanOptions extends CreateLocalFelanRuntimeOptions {
+  readonly initialMessage?: string;
+  readonly verbose?: boolean;
+}
+
+export async function runLocalFelan(options: RunLocalFelanOptions = {}): Promise<void> {
+  const runtime = await createLocalFelanRuntime(options);
+  const mode = new InteractiveMode(runtime, {
+    ...(options.initialMessage === undefined ? {} : { initialMessage: options.initialMessage }),
+    ...(options.verbose === undefined ? {} : { verbose: options.verbose }),
+  });
+
+  try {
+    await mode.run();
+  } catch (error) {
+    await runtime.dispose();
+    throw error;
+  }
+}

--- a/apps/tui/src/application.ts
+++ b/apps/tui/src/application.ts
@@ -8,15 +8,24 @@ export interface RunLocalFelanOptions extends CreateLocalFelanRuntimeOptions {
 
 export async function runLocalFelan(options: RunLocalFelanOptions = {}): Promise<void> {
   const runtime = await createLocalFelanRuntime(options);
-  const mode = new InteractiveMode(runtime, {
-    ...(options.initialMessage === undefined ? {} : { initialMessage: options.initialMessage }),
-    ...(options.verbose === undefined ? {} : { verbose: options.verbose }),
-  });
+  const previousPiAgentDir = process.env.PI_CODING_AGENT_DIR;
+  process.env.PI_CODING_AGENT_DIR = runtime.services.agentDir;
 
   try {
+    const mode = new InteractiveMode(runtime, {
+      ...(options.initialMessage === undefined ? {} : { initialMessage: options.initialMessage }),
+      ...(options.verbose === undefined ? {} : { verbose: options.verbose }),
+    });
     await mode.run();
-  } catch (error) {
-    await runtime.dispose();
-    throw error;
+  } finally {
+    try {
+      await runtime.dispose();
+    } finally {
+      if (previousPiAgentDir === undefined) {
+        delete process.env.PI_CODING_AGENT_DIR;
+      } else {
+        process.env.PI_CODING_AGENT_DIR = previousPiAgentDir;
+      }
+    }
   }
 }

--- a/apps/tui/src/cli-main.ts
+++ b/apps/tui/src/cli-main.ts
@@ -1,0 +1,69 @@
+import { AGENT_CORE_VERSION } from '@felan-ai/agent-core';
+import { VERSION as PI_VERSION } from '@earendil-works/pi-coding-agent';
+import { runLocalFelan, type RunLocalFelanOptions } from './application.js';
+import { FELAN_VERSION } from './version.js';
+
+export interface CliDependencies {
+  readonly writeOutput?: (line: string) => void;
+  readonly writeError?: (line: string) => void;
+  readonly launch?: (options: RunLocalFelanOptions) => Promise<void>;
+}
+
+const help = `Usage: felan [options] [message]
+
+Options:
+  -c, --continue     Continue the most recent session for this directory
+  --diagnostics      Print local runtime versions and configuration mode
+  -h, --help         Show this help
+  -v, --version      Print the Felan version
+  --verbose          Show verbose startup details`;
+
+export async function runCli(args: readonly string[], dependencies: CliDependencies = {}): Promise<number> {
+  const writeOutput = dependencies.writeOutput ?? ((line) => console.log(line));
+  const writeError = dependencies.writeError ?? ((line) => console.error(line));
+  const launch = dependencies.launch ?? runLocalFelan;
+  let continueRecent = false;
+  let verbose = false;
+  const messageParts: string[] = [];
+  let positionalOnly = false;
+
+  for (const argument of args) {
+    if (positionalOnly) {
+      messageParts.push(argument);
+      continue;
+    }
+    if (argument === '--') {
+      positionalOnly = true;
+    } else if (argument === '-c' || argument === '--continue') {
+      continueRecent = true;
+    } else if (argument === '--verbose') {
+      verbose = true;
+    } else if (argument === '-h' || argument === '--help') {
+      writeOutput(help);
+      return 0;
+    } else if (argument === '-v' || argument === '--version') {
+      writeOutput(FELAN_VERSION);
+      return 0;
+    } else if (argument === '--diagnostics') {
+      writeOutput(`Felan version: ${FELAN_VERSION}`);
+      writeOutput(`Agent Core version: ${AGENT_CORE_VERSION}`);
+      writeOutput(`Pi version: ${PI_VERSION}`);
+      writeOutput(`Node version: ${process.versions.node}`);
+      writeOutput('Runtime: host');
+      writeOutput('Credentials: local');
+      return 0;
+    } else if (argument.startsWith('-')) {
+      writeError(`Unknown option: ${argument}`);
+      return 1;
+    } else {
+      messageParts.push(argument);
+    }
+  }
+
+  await launch({
+    continueRecent,
+    verbose,
+    ...(messageParts.length === 0 ? {} : { initialMessage: messageParts.join(' ') }),
+  });
+  return 0;
+}

--- a/apps/tui/src/cli.ts
+++ b/apps/tui/src/cli.ts
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+import { runCli } from './cli-main.js';
+
+process.exitCode = await runCli(process.argv.slice(2));

--- a/apps/tui/src/extensions.ts
+++ b/apps/tui/src/extensions.ts
@@ -1,0 +1,21 @@
+import type { ExtensionPackageImporter } from '@felan-ai/agent-core';
+
+export const localExtensionPackages = [
+  '@felan-ai/ext-prewalk',
+  '@felan-ai/ext-context',
+  '@felan-ai/ext-powerline',
+] as const;
+
+const localExtensionImporters: Record<string, () => Promise<unknown>> = {
+  '@felan-ai/ext-prewalk': () => import('@felan-ai/ext-prewalk'),
+  '@felan-ai/ext-context': () => import('@felan-ai/ext-context'),
+  '@felan-ai/ext-powerline': () => import('@felan-ai/ext-powerline'),
+};
+
+export const importLocalExtension: ExtensionPackageImporter = async (packageName) => {
+  const importExtension = localExtensionImporters[packageName];
+  if (!importExtension) {
+    throw new Error(`Unknown local extension package: ${packageName}`);
+  }
+  return importExtension();
+};

--- a/apps/tui/src/index.ts
+++ b/apps/tui/src/index.ts
@@ -1,5 +1,18 @@
-export const localExtensionPackages = [
-  '@felan-ai/ext-prewalk',
-  '@felan-ai/ext-context',
-  '@felan-ai/ext-powerline',
-] as const;
+export { runLocalFelan } from './application.js';
+export type { RunLocalFelanOptions } from './application.js';
+export { runCli } from './cli-main.js';
+export type { CliDependencies } from './cli-main.js';
+export { importLocalExtension, localExtensionPackages } from './extensions.js';
+export {
+  createLocalFelanRuntime,
+  createLocalModelRuntime,
+  createLocalSessionHost,
+  createLocalSessionRuntimeFactory,
+  getLocalAgentDir,
+} from './runtime.js';
+export type {
+  CreateLocalFelanRuntimeOptions,
+  CreateLocalSessionRuntimeFactoryOptions,
+} from './runtime.js';
+export { createLocalSettingsManager } from './settings.js';
+export { FELAN_VERSION } from './version.js';

--- a/apps/tui/src/runtime.ts
+++ b/apps/tui/src/runtime.ts
@@ -123,7 +123,12 @@ export function createLocalSessionHost(
           ? {}
           : { thinkingLevel: resolvedModel.thinkingLevel }),
       });
-      await created.session.bindExtensions({ mode: 'print' });
+      try {
+        await created.session.bindExtensions({ mode: 'print' });
+      } catch (error) {
+        created.session.dispose();
+        throw error;
+      }
 
       const runChild = async () => {
         let timeout: ReturnType<typeof setTimeout> | undefined;

--- a/apps/tui/src/runtime.ts
+++ b/apps/tui/src/runtime.ts
@@ -1,0 +1,229 @@
+import { mkdir } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
+import {
+  AGENT_CORE_VERSION,
+  HostAgentRuntime,
+  ModelRuntime,
+  SessionManager,
+  createAgentCoreSession,
+  createAgentCoreSessionRuntimeFactory,
+  createAgentSessionRuntime,
+  type AgentRuntime,
+  type AgentSessionHost,
+  type CreateAgentSessionRuntimeFactory,
+  type ExtensionPackageImporter,
+} from '@felan-ai/agent-core';
+import {
+  resolveCliModel,
+  resolveModelScopeWithDiagnostics,
+} from '@earendil-works/pi-coding-agent';
+import { importLocalExtension, localExtensionPackages } from './extensions.js';
+import { createLocalSettingsManager } from './settings.js';
+
+export interface CreateLocalSessionRuntimeFactoryOptions {
+  readonly agentDir: string;
+  readonly modelRuntime: ModelRuntime;
+  readonly extensionPackages?: readonly string[];
+  readonly importExtension?: ExtensionPackageImporter;
+  readonly runtimeFactory?: (cwd: string) => AgentRuntime;
+}
+
+export interface CreateLocalFelanRuntimeOptions {
+  readonly cwd?: string;
+  readonly agentDir?: string;
+  readonly continueRecent?: boolean;
+  readonly sessionManager?: SessionManager;
+  readonly modelRuntime?: ModelRuntime;
+  readonly sessionDir?: string;
+  readonly runtimeFactory?: (cwd: string) => AgentRuntime;
+}
+
+export function getLocalAgentDir(): string {
+  return resolve(process.env.FELAN_AGENT_DIR ?? join(homedir(), '.felan', 'agent'));
+}
+
+export function createLocalSessionRuntimeFactory(
+  options: CreateLocalSessionRuntimeFactoryOptions,
+): CreateAgentSessionRuntimeFactory {
+  const createCoreRuntime = createAgentCoreSessionRuntimeFactory(async ({ cwd }) => {
+    const settingsManager = createLocalSettingsManager(cwd, options.agentDir);
+    const modelPatterns = settingsManager.getEnabledModels();
+    const modelScope = modelPatterns && modelPatterns.length > 0
+      ? await resolveModelScopeWithDiagnostics(modelPatterns, options.modelRuntime)
+      : { scopedModels: [], diagnostics: [] };
+
+    return {
+      applicationKind: 'tui',
+      runtime: options.runtimeFactory?.(cwd) ?? new HostAgentRuntime(cwd),
+      host: createLocalSessionHost(options, cwd),
+      extensionPackages: options.extensionPackages ?? localExtensionPackages,
+      importExtension: options.importExtension ?? importLocalExtension,
+      modelRuntime: options.modelRuntime,
+      settingsManager,
+      ...(modelScope.scopedModels.length === 0 ? {} : { scopedModels: modelScope.scopedModels }),
+    };
+  });
+
+  return async (request) => {
+    const result = await createCoreRuntime(request);
+    const settingsErrors = result.services.settingsManager.drainErrors();
+    const modelPatterns = result.services.settingsManager.getEnabledModels();
+    const modelScope = modelPatterns && modelPatterns.length > 0
+      ? await resolveModelScopeWithDiagnostics(modelPatterns, options.modelRuntime)
+      : { diagnostics: [] };
+
+    return {
+      ...result,
+      diagnostics: [
+        { type: 'info', message: `Agent Core version: ${AGENT_CORE_VERSION}` },
+        ...result.diagnostics,
+        ...modelScope.diagnostics,
+        ...settingsErrors.map(({ scope, error }) => ({
+          type: 'warning' as const,
+          message: `${scope} settings: ${error.message}`,
+        })),
+      ],
+    };
+  };
+}
+
+export function createLocalSessionHost(
+  options: CreateLocalSessionRuntimeFactoryOptions,
+  cwd: string,
+): AgentSessionHost {
+  return {
+    createChildSession: async (request) => {
+      const sessionManager = SessionManager.inMemory(cwd);
+      const childSessionId = sessionManager.getSessionId();
+      const resolvedModel = request.model
+        ? resolveCliModel({ cliModel: request.model, modelRuntime: options.modelRuntime })
+        : undefined;
+      if (resolvedModel?.error) {
+        return {
+          ok: false,
+          sessionId: childSessionId,
+          status: 'failed',
+          error: resolvedModel.error,
+        };
+      }
+
+      const created = await createAgentCoreSession({
+        applicationKind: 'tui',
+        runtime: options.runtimeFactory?.(cwd) ?? new HostAgentRuntime(cwd),
+        host: createLocalSessionHost(options, cwd),
+        extensionPackages: options.extensionPackages ?? localExtensionPackages,
+        importExtension: options.importExtension ?? importLocalExtension,
+        modelRuntime: options.modelRuntime,
+        settingsManager: createLocalSettingsManager(cwd, options.agentDir),
+        sessionManager,
+        appendSystemPrompt: [`You are the ${request.personaId} child agent.`],
+        ...(resolvedModel?.model === undefined ? {} : { model: resolvedModel.model }),
+        ...(resolvedModel?.thinkingLevel === undefined
+          ? {}
+          : { thinkingLevel: resolvedModel.thinkingLevel }),
+      });
+      await created.session.bindExtensions({ mode: 'print' });
+
+      const runChild = async () => {
+        let timeout: ReturnType<typeof setTimeout> | undefined;
+        if (request.timeoutMinutes) {
+          timeout = setTimeout(() => void created.session.abort(), request.timeoutMinutes * 60_000);
+          timeout.unref();
+        }
+
+        try {
+          await created.session.prompt(request.prompt);
+          let assistant: Extract<(typeof created.session.messages)[number], { role: 'assistant' }> | undefined;
+          for (let index = created.session.messages.length - 1; index >= 0; index -= 1) {
+            const message = created.session.messages[index];
+            if (message?.role === 'assistant') {
+              assistant = message;
+              break;
+            }
+          }
+          if (!assistant) {
+            return {
+              ok: false,
+              sessionId: childSessionId,
+              status: 'failed' as const,
+              error: 'Child session completed without an assistant response',
+            };
+          }
+          if (assistant.stopReason === 'error' || assistant.stopReason === 'aborted') {
+            return {
+              ok: false,
+              sessionId: childSessionId,
+              status: 'failed' as const,
+              error: assistant.errorMessage ?? `Child session ${assistant.stopReason}`,
+            };
+          }
+          const result = assistant.content
+            .filter((part) => part.type === 'text')
+            .map((part) => part.text)
+            .join('\n');
+          return {
+            ok: true,
+            sessionId: childSessionId,
+            status: 'completed' as const,
+            result,
+          };
+        } catch (error) {
+          return {
+            ok: false,
+            sessionId: childSessionId,
+            status: 'failed' as const,
+            error: error instanceof Error ? error.message : String(error),
+          };
+        } finally {
+          if (timeout) clearTimeout(timeout);
+          created.session.dispose();
+        }
+      };
+
+      if (!request.block) {
+        void runChild();
+        return {
+          ok: true,
+          sessionId: childSessionId,
+          status: 'running',
+          message: 'Child session started',
+        };
+      }
+      return runChild();
+    },
+  };
+}
+
+export async function createLocalModelRuntime(agentDir: string): Promise<ModelRuntime> {
+  return ModelRuntime.create({
+    authPath: join(agentDir, 'auth.json'),
+    modelsPath: join(agentDir, 'models.json'),
+  });
+}
+
+export async function createLocalFelanRuntime(
+  options: CreateLocalFelanRuntimeOptions = {},
+) {
+  const cwd = resolve(options.cwd ?? process.cwd());
+  const agentDir = resolve(options.agentDir ?? getLocalAgentDir());
+  await mkdir(agentDir, { recursive: true });
+  const modelRuntime = options.modelRuntime ?? await createLocalModelRuntime(agentDir);
+  const startupSettings = createLocalSettingsManager(cwd, agentDir);
+  const sessionDir = options.sessionDir ?? startupSettings.getSessionDir();
+  const sessionManager = options.sessionManager
+    ?? (options.continueRecent
+      ? SessionManager.continueRecent(cwd, sessionDir)
+      : SessionManager.create(cwd, sessionDir));
+  const createRuntime = createLocalSessionRuntimeFactory({
+    agentDir,
+    modelRuntime,
+    ...(options.runtimeFactory === undefined ? {} : { runtimeFactory: options.runtimeFactory }),
+  });
+
+  return createAgentSessionRuntime(createRuntime, {
+    cwd: sessionManager.getCwd(),
+    agentDir,
+    sessionManager,
+  });
+}

--- a/apps/tui/src/settings.ts
+++ b/apps/tui/src/settings.ts
@@ -2,12 +2,29 @@ import { SettingsManager } from '@felan-ai/agent-core';
 
 export function createLocalSettingsManager(cwd: string, agentDir: string): SettingsManager {
   const settingsManager = SettingsManager.create(cwd, agentDir);
-  settingsManager.applyOverrides({
+  const filteredResources = {
     packages: [],
     extensions: [],
     skills: [],
     prompts: [],
     themes: [],
+  };
+  const reload = settingsManager.reload.bind(settingsManager);
+  const getGlobalSettings = settingsManager.getGlobalSettings.bind(settingsManager);
+  const getProjectSettings = settingsManager.getProjectSettings.bind(settingsManager);
+
+  settingsManager.applyOverrides(filteredResources);
+  settingsManager.reload = async () => {
+    await reload();
+    settingsManager.applyOverrides(filteredResources);
+  };
+  settingsManager.getGlobalSettings = () => ({
+    ...getGlobalSettings(),
+    ...filteredResources,
+  });
+  settingsManager.getProjectSettings = () => ({
+    ...getProjectSettings(),
+    ...filteredResources,
   });
   return settingsManager;
 }

--- a/apps/tui/src/settings.ts
+++ b/apps/tui/src/settings.ts
@@ -1,0 +1,13 @@
+import { SettingsManager } from '@felan-ai/agent-core';
+
+export function createLocalSettingsManager(cwd: string, agentDir: string): SettingsManager {
+  const settingsManager = SettingsManager.create(cwd, agentDir);
+  settingsManager.applyOverrides({
+    packages: [],
+    extensions: [],
+    skills: [],
+    prompts: [],
+    themes: [],
+  });
+  return settingsManager;
+}

--- a/apps/tui/src/version.ts
+++ b/apps/tui/src/version.ts
@@ -1,0 +1,5 @@
+import { createRequire } from 'node:module';
+
+const packageJson = createRequire(import.meta.url)('../package.json') as { version: string };
+
+export const FELAN_VERSION = packageJson.version;

--- a/apps/tui/test/application.test.ts
+++ b/apps/tui/test/application.test.ts
@@ -1,0 +1,59 @@
+import { mkdtemp, mkdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const interactive = vi.hoisted(() => ({
+  runs: 0,
+  toolNames: [] as string[],
+}));
+
+vi.mock('@earendil-works/pi-coding-agent', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@earendil-works/pi-coding-agent')>();
+  return {
+    ...original,
+    InteractiveMode: class {
+      constructor(private runtime: InstanceType<typeof original.AgentSessionRuntime>) {}
+
+      async run() {
+        interactive.runs += 1;
+        interactive.toolNames = this.runtime.session.agent.state.tools.map((tool) => tool.name);
+        await this.runtime.dispose();
+      }
+    },
+  };
+});
+
+import { runLocalFelan } from '../src/application.js';
+
+const temporaryPaths: string[] = [];
+
+afterEach(async () => {
+  interactive.runs = 0;
+  interactive.toolNames = [];
+  await Promise.all(temporaryPaths.splice(0).map((path) => rm(path, { force: true, recursive: true })));
+});
+
+describe('interactive application', () => {
+  it('runs Pi InteractiveMode with the composed local Agent Core runtime', async () => {
+    const root = await temporaryDirectory();
+    const cwd = join(root, 'workspace');
+    const agentDir = join(root, 'agent');
+    await mkdir(cwd, { recursive: true });
+
+    await runLocalFelan({ cwd, agentDir });
+
+    expect(interactive.runs).toBe(1);
+    expect(interactive.toolNames).toEqual(expect.arrayContaining([
+      'read',
+      'bash',
+      'spawn_agent',
+    ]));
+  });
+});
+
+async function temporaryDirectory(): Promise<string> {
+  const path = await mkdtemp(join(tmpdir(), 'felan-tui-application-'));
+  temporaryPaths.push(path);
+  return path;
+}

--- a/apps/tui/test/application.test.ts
+++ b/apps/tui/test/application.test.ts
@@ -4,6 +4,10 @@ import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const interactive = vi.hoisted(() => ({
+  agentDirs: [] as Array<string | undefined>,
+  constructorError: undefined as Error | undefined,
+  disposals: 0,
+  runError: undefined as Error | undefined,
   runs: 0,
   toolNames: [] as string[],
 }));
@@ -13,12 +17,20 @@ vi.mock('@earendil-works/pi-coding-agent', async (importOriginal) => {
   return {
     ...original,
     InteractiveMode: class {
-      constructor(private runtime: InstanceType<typeof original.AgentSessionRuntime>) {}
+      constructor(private runtime: InstanceType<typeof original.AgentSessionRuntime>) {
+        interactive.agentDirs.push(process.env.PI_CODING_AGENT_DIR);
+        const dispose = runtime.dispose.bind(runtime);
+        runtime.dispose = async () => {
+          interactive.disposals += 1;
+          await dispose();
+        };
+        if (interactive.constructorError) throw interactive.constructorError;
+      }
 
       async run() {
         interactive.runs += 1;
         interactive.toolNames = this.runtime.session.agent.state.tools.map((tool) => tool.name);
-        await this.runtime.dispose();
+        if (interactive.runError) throw interactive.runError;
       }
     },
   };
@@ -29,6 +41,10 @@ import { runLocalFelan } from '../src/application.js';
 const temporaryPaths: string[] = [];
 
 afterEach(async () => {
+  interactive.agentDirs = [];
+  interactive.constructorError = undefined;
+  interactive.disposals = 0;
+  interactive.runError = undefined;
   interactive.runs = 0;
   interactive.toolNames = [];
   await Promise.all(temporaryPaths.splice(0).map((path) => rm(path, { force: true, recursive: true })));
@@ -39,16 +55,46 @@ describe('interactive application', () => {
     const root = await temporaryDirectory();
     const cwd = join(root, 'workspace');
     const agentDir = join(root, 'agent');
+    const previousPiAgentDir = process.env.PI_CODING_AGENT_DIR;
     await mkdir(cwd, { recursive: true });
 
     await runLocalFelan({ cwd, agentDir });
 
     expect(interactive.runs).toBe(1);
+    expect(interactive.agentDirs).toEqual([agentDir]);
+    expect(interactive.disposals).toBe(1);
+    expect(process.env.PI_CODING_AGENT_DIR).toBe(previousPiAgentDir);
     expect(interactive.toolNames).toEqual(expect.arrayContaining([
       'read',
       'bash',
       'spawn_agent',
     ]));
+  });
+
+  it('disposes the runtime when InteractiveMode construction fails', async () => {
+    const root = await temporaryDirectory();
+    const cwd = join(root, 'workspace');
+    const agentDir = join(root, 'agent');
+    await mkdir(cwd, { recursive: true });
+    interactive.constructorError = new Error('constructor failed');
+
+    await expect(runLocalFelan({ cwd, agentDir })).rejects.toThrow('constructor failed');
+
+    expect(interactive.runs).toBe(0);
+    expect(interactive.disposals).toBe(1);
+  });
+
+  it('disposes the runtime when InteractiveMode.run fails', async () => {
+    const root = await temporaryDirectory();
+    const cwd = join(root, 'workspace');
+    const agentDir = join(root, 'agent');
+    await mkdir(cwd, { recursive: true });
+    interactive.runError = new Error('run failed');
+
+    await expect(runLocalFelan({ cwd, agentDir })).rejects.toThrow('run failed');
+
+    expect(interactive.runs).toBe(1);
+    expect(interactive.disposals).toBe(1);
   });
 });
 

--- a/apps/tui/test/child-session.test.ts
+++ b/apps/tui/test/child-session.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const childRun = vi.hoisted(() => ({
+  bindError: undefined as Error | undefined,
   bindModes: [] as string[],
   prompts: [] as string[],
   disposed: 0,
@@ -22,6 +23,7 @@ vi.mock('@felan-ai/agent-core', async (importOriginal) => {
           messages,
           bindExtensions: async ({ mode }: { mode: string }) => {
             childRun.bindModes.push(mode);
+            if (childRun.bindError) throw childRun.bindError;
           },
           prompt: async (prompt: string) => {
             childRun.prompts.push(prompt);
@@ -52,6 +54,7 @@ import {
 const temporaryPaths: string[] = [];
 
 afterEach(async () => {
+  childRun.bindError = undefined;
   childRun.bindModes = [];
   childRun.prompts = [];
   childRun.disposed = 0;
@@ -100,6 +103,34 @@ describe('local child session host', () => {
     expect(options.host).not.toBe(host);
     expect(childRun.bindModes).toEqual(['print']);
     expect(childRun.prompts).toEqual(['Review the implementation']);
+    expect(childRun.disposed).toBe(1);
+  });
+
+  it('disposes the child session when extension binding fails', async () => {
+    const root = await temporaryDirectory();
+    const cwd = join(root, 'workspace');
+    const agentDir = join(root, 'agent');
+    const modelRuntime = await createLocalModelRuntime(agentDir);
+    const host = createLocalSessionHost({
+      agentDir,
+      modelRuntime,
+      extensionPackages: [],
+      importExtension: async () => {
+        throw new Error('No extension import expected');
+      },
+    }, cwd);
+    childRun.bindError = new Error('bind failed');
+
+    await expect(host.createChildSession({
+      rootSessionId: 'root-1',
+      parentSessionId: 'parent-1',
+      personaId: 'reviewer',
+      prompt: 'Review the implementation',
+      block: true,
+    })).rejects.toThrow('bind failed');
+
+    expect(childRun.bindModes).toEqual(['print']);
+    expect(childRun.prompts).toEqual([]);
     expect(childRun.disposed).toBe(1);
   });
 });

--- a/apps/tui/test/child-session.test.ts
+++ b/apps/tui/test/child-session.test.ts
@@ -1,0 +1,111 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const childRun = vi.hoisted(() => ({
+  bindModes: [] as string[],
+  prompts: [] as string[],
+  disposed: 0,
+  options: [] as unknown[],
+}));
+
+vi.mock('@felan-ai/agent-core', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@felan-ai/agent-core')>();
+  return {
+    ...original,
+    createAgentCoreSession: vi.fn(async (options: unknown) => {
+      childRun.options.push(options);
+      const messages: unknown[] = [];
+      return {
+        session: {
+          messages,
+          bindExtensions: async ({ mode }: { mode: string }) => {
+            childRun.bindModes.push(mode);
+          },
+          prompt: async (prompt: string) => {
+            childRun.prompts.push(prompt);
+            messages.push({
+              role: 'assistant',
+              content: [{ type: 'text', text: 'Review complete' }],
+              stopReason: 'stop',
+            });
+          },
+          dispose: () => {
+            childRun.disposed += 1;
+          },
+        },
+      };
+    }),
+  };
+});
+
+import {
+  HostAgentRuntime,
+  type CreateAgentCoreSessionOptions,
+} from '@felan-ai/agent-core';
+import {
+  createLocalModelRuntime,
+  createLocalSessionHost,
+} from '../src/runtime.js';
+
+const temporaryPaths: string[] = [];
+
+afterEach(async () => {
+  childRun.bindModes = [];
+  childRun.prompts = [];
+  childRun.disposed = 0;
+  childRun.options = [];
+  await Promise.all(temporaryPaths.splice(0).map((path) => rm(path, { force: true, recursive: true })));
+});
+
+describe('local child session host', () => {
+  it('runs a child Agent Core session on a fresh host runtime', async () => {
+    const root = await temporaryDirectory();
+    const cwd = join(root, 'workspace');
+    const agentDir = join(root, 'agent');
+    const modelRuntime = await createLocalModelRuntime(agentDir);
+    const runtimes: HostAgentRuntime[] = [];
+    const host = createLocalSessionHost({
+      agentDir,
+      modelRuntime,
+      extensionPackages: [],
+      importExtension: async () => {
+        throw new Error('No extension import expected');
+      },
+      runtimeFactory: (runtimeCwd) => {
+        const runtime = new HostAgentRuntime(runtimeCwd);
+        runtimes.push(runtime);
+        return runtime;
+      },
+    }, cwd);
+
+    const result = await host.createChildSession({
+      rootSessionId: 'root-1',
+      parentSessionId: 'parent-1',
+      personaId: 'reviewer',
+      prompt: 'Review the implementation',
+      block: true,
+    });
+    const options = childRun.options[0] as CreateAgentCoreSessionOptions;
+
+    expect(result).toMatchObject({
+      ok: true,
+      status: 'completed',
+      result: 'Review complete',
+    });
+    expect(runtimes).toHaveLength(1);
+    expect(runtimes[0]?.cwd).toBe(cwd);
+    expect(options.runtime).toBe(runtimes[0]);
+    expect(options.host).not.toBe(host);
+    expect(childRun.bindModes).toEqual(['print']);
+    expect(childRun.prompts).toEqual(['Review the implementation']);
+    expect(childRun.disposed).toBe(1);
+  });
+});
+
+async function temporaryDirectory(): Promise<string> {
+  const path = await mkdtemp(join(tmpdir(), 'felan-tui-child-'));
+  temporaryPaths.push(path);
+  return path;
+}

--- a/apps/tui/test/cli.test.ts
+++ b/apps/tui/test/cli.test.ts
@@ -12,6 +12,8 @@ describe('felan CLI', () => {
     });
 
     expect(exitCode).toBe(0);
+    expect(FELAN_VERSION).toBe('0.1.0-alpha.2');
+    expect(AGENT_CORE_VERSION).toBe('0.1.0-alpha.2');
     expect(output).toContain(`Felan version: ${FELAN_VERSION}`);
     expect(output).toContain(`Agent Core version: ${AGENT_CORE_VERSION}`);
     expect(output).toContain('Runtime: host');

--- a/apps/tui/test/cli.test.ts
+++ b/apps/tui/test/cli.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { AGENT_CORE_VERSION } from '@felan-ai/agent-core';
+import { runCli } from '../src/cli-main.js';
+import { FELAN_VERSION } from '../src/version.js';
+
+describe('felan CLI', () => {
+  it('reports Felan and Agent Core versions in diagnostics', async () => {
+    const output: string[] = [];
+
+    const exitCode = await runCli(['--diagnostics'], {
+      writeOutput: (line) => output.push(line),
+    });
+
+    expect(exitCode).toBe(0);
+    expect(output).toContain(`Felan version: ${FELAN_VERSION}`);
+    expect(output).toContain(`Agent Core version: ${AGENT_CORE_VERSION}`);
+    expect(output).toContain('Runtime: host');
+    expect(output).toContain('Credentials: local');
+  });
+
+  it('passes continue, verbosity, and initial input to the interactive application', async () => {
+    const launches: unknown[] = [];
+
+    const exitCode = await runCli(['--continue', '--verbose', 'inspect', 'this project'], {
+      launch: async (options) => {
+        launches.push(options);
+      },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(launches).toEqual([{
+      continueRecent: true,
+      verbose: true,
+      initialMessage: 'inspect this project',
+    }]);
+  });
+
+  it('rejects unknown options before starting the TUI', async () => {
+    const errors: string[] = [];
+    let launched = false;
+
+    const exitCode = await runCli(['--cloud'], {
+      writeError: (line) => errors.push(line),
+      launch: async () => {
+        launched = true;
+      },
+    });
+
+    expect(exitCode).toBe(1);
+    expect(errors).toEqual(['Unknown option: --cloud']);
+    expect(launched).toBe(false);
+  });
+});

--- a/apps/tui/test/extensions.test.ts
+++ b/apps/tui/test/extensions.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { importLocalExtension, localExtensionPackages } from '../src/extensions.js';
+
+describe('local extension importer', () => {
+  it('imports only the source-controlled package list', async () => {
+    expect(localExtensionPackages).toEqual([
+      '@felan-ai/ext-prewalk',
+      '@felan-ai/ext-context',
+      '@felan-ai/ext-powerline',
+    ]);
+
+    for (const packageName of localExtensionPackages) {
+      await expect(importLocalExtension(packageName)).resolves.toMatchObject({
+        default: expect.any(Function),
+      });
+    }
+    await expect(importLocalExtension('@felan-ai/ambient')).rejects.toThrow(
+      'Unknown local extension package: @felan-ai/ambient',
+    );
+  });
+});

--- a/apps/tui/test/runtime.test.ts
+++ b/apps/tui/test/runtime.test.ts
@@ -7,6 +7,7 @@ import {
   SessionManager,
   createAgentSessionRuntime,
 } from '@felan-ai/agent-core';
+import { InteractiveMode } from '@earendil-works/pi-coding-agent';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
   createLocalModelRuntime,
@@ -137,6 +138,59 @@ describe('local Agent Core lifecycle', () => {
     expect(reboundCwds).toEqual([cwdA, cwdA, cwdB, cwdC]);
 
     await runtime.dispose();
+  });
+
+  it('rebinds a replacement session through Pi InteractiveMode command handling', async () => {
+    const root = await temporaryDirectory();
+    const cwd = join(root, 'workspace');
+    const agentDir = join(root, 'agent');
+    await Promise.all([cwd, agentDir].map((path) => mkdir(path, { recursive: true })));
+    const modelRuntime = await createLocalModelRuntime(agentDir);
+    const createdHostRuntimes: HostAgentRuntime[] = [];
+    const createRuntime = createLocalSessionRuntimeFactory({
+      agentDir,
+      modelRuntime,
+      extensionPackages: [],
+      importExtension: async () => {
+        throw new Error('No extensions should be imported');
+      },
+      runtimeFactory: (runtimeCwd) => {
+        const hostRuntime = new HostAgentRuntime(runtimeCwd);
+        createdHostRuntimes.push(hostRuntime);
+        return hostRuntime;
+      },
+    });
+    const runtime = await createAgentSessionRuntime(createRuntime, {
+      cwd,
+      agentDir,
+      sessionManager: SessionManager.inMemory(cwd),
+    });
+    const initialSession = runtime.session;
+    const previousPiAgentDir = process.env.PI_CODING_AGENT_DIR;
+    process.env.PI_CODING_AGENT_DIR = agentDir;
+    const mode = new InteractiveMode(runtime);
+
+    try {
+      await (mode as unknown as { handleClearCommand(): Promise<void> }).handleClearCommand();
+
+      expect(runtime.session).not.toBe(initialSession);
+      expect(runtime.services.agentDir).toBe(agentDir);
+      expect(createdHostRuntimes.map((hostRuntime) => hostRuntime.cwd)).toEqual([cwd, cwd]);
+      expect((runtime.session as unknown as { _extensionMode?: string })._extensionMode).toBe('tui');
+      expect(runtime.session.agent.state.tools.map((tool) => tool.name)).toEqual(expect.arrayContaining([
+        'read',
+        'bash',
+        'spawn_agent',
+      ]));
+    } finally {
+      mode.stop();
+      await runtime.dispose();
+      if (previousPiAgentDir === undefined) {
+        delete process.env.PI_CODING_AGENT_DIR;
+      } else {
+        process.env.PI_CODING_AGENT_DIR = previousPiAgentDir;
+      }
+    }
   });
 });
 

--- a/apps/tui/test/runtime.test.ts
+++ b/apps/tui/test/runtime.test.ts
@@ -1,0 +1,167 @@
+import { mkdtemp, mkdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  AGENT_CORE_VERSION,
+  HostAgentRuntime,
+  SessionManager,
+  createAgentSessionRuntime,
+} from '@felan-ai/agent-core';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  createLocalModelRuntime,
+  createLocalSessionRuntimeFactory,
+} from '../src/runtime.js';
+
+const temporaryPaths: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryPaths.splice(0).map((path) => rm(path, { force: true, recursive: true })));
+});
+
+describe('local Agent Core lifecycle', () => {
+  it('recreates cwd-bound host runtime and services for fork, new, resume, and import', async () => {
+    const root = await temporaryDirectory();
+    const cwdA = join(root, 'workspace-a');
+    const cwdB = join(root, 'workspace-b');
+    const cwdC = join(root, 'workspace-c');
+    const agentDir = join(root, 'agent');
+    const sessionDir = join(root, 'sessions');
+    const importDir = join(root, 'imports');
+    await Promise.all([cwdA, cwdB, cwdC, agentDir, sessionDir, importDir].map(
+      (path) => mkdir(path, { recursive: true }),
+    ));
+
+    const createdHostRuntimes: HostAgentRuntime[] = [];
+    const modelRuntime = await createLocalModelRuntime(agentDir);
+    const createRuntime = createLocalSessionRuntimeFactory({
+      agentDir,
+      modelRuntime,
+      extensionPackages: [],
+      importExtension: async () => {
+        throw new Error('No extensions should be imported');
+      },
+      runtimeFactory: (cwd) => {
+        const hostRuntime = new HostAgentRuntime(cwd);
+        createdHostRuntimes.push(hostRuntime);
+        return hostRuntime;
+      },
+    });
+    const initialSessionManager = SessionManager.create(cwdA, sessionDir);
+    const entryId = initialSessionManager.appendMessage({
+      role: 'user',
+      content: 'initial prompt',
+      timestamp: Date.now(),
+    });
+    initialSessionManager.appendMessage({
+      role: 'assistant',
+      content: [{ type: 'text', text: 'initial response' }],
+      api: 'anthropic-messages',
+      provider: 'anthropic',
+      model: 'test-model',
+      usage: {
+        input: 1,
+        output: 1,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 2,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: 'stop',
+      timestamp: Date.now(),
+    });
+    const runtime = await createAgentSessionRuntime(createRuntime, {
+      cwd: cwdA,
+      agentDir,
+      sessionManager: initialSessionManager,
+    });
+    const reboundCwds: string[] = [];
+    runtime.setRebindSession(async (session) => {
+      reboundCwds.push(session.sessionManager.getCwd());
+    });
+
+    const initialServices = runtime.services;
+    expect(runtime.diagnostics).toContainEqual({
+      type: 'info',
+      message: `Agent Core version: ${AGENT_CORE_VERSION}`,
+    });
+    expect(runtime.session.agent.state.tools.map((tool) => tool.name)).toEqual([
+      'read',
+      'bash',
+      'edit',
+      'write',
+      'grep',
+      'find',
+      'ls',
+      'spawn_agent',
+    ]);
+
+    await runtime.fork(entryId, { position: 'at' });
+    const forkServices = runtime.services;
+    expect(forkServices).not.toBe(initialServices);
+    expect(runtime.cwd).toBe(cwdA);
+
+    await runtime.newSession();
+    const newServices = runtime.services;
+    expect(newServices).not.toBe(forkServices);
+    expect(runtime.cwd).toBe(cwdA);
+
+    const resumedSession = SessionManager.create(cwdB, sessionDir);
+    resumedSession.appendMessage({ role: 'user', content: 'resume', timestamp: Date.now() });
+    resumedSession.appendMessage(completedAssistantMessage('resumed'));
+    const resumedPath = resumedSession.getSessionFile();
+    expect(resumedPath).toBeDefined();
+    await runtime.switchSession(resumedPath!);
+    const resumedServices = runtime.services;
+    expect(resumedServices).not.toBe(newServices);
+    expect(runtime.cwd).toBe(cwdB);
+
+    const importedSession = SessionManager.create(cwdC, importDir);
+    importedSession.appendMessage({ role: 'user', content: 'imported', timestamp: Date.now() });
+    importedSession.appendMessage(completedAssistantMessage('imported'));
+    const importPath = importedSession.getSessionFile();
+    expect(importPath).toBeDefined();
+    await runtime.importFromJsonl(importPath!);
+    expect(runtime.services).not.toBe(resumedServices);
+    expect(runtime.cwd).toBe(cwdC);
+
+    expect(createdHostRuntimes).toHaveLength(5);
+    expect(new Set(createdHostRuntimes).size).toBe(5);
+    expect(createdHostRuntimes.map((hostRuntime) => hostRuntime.cwd)).toEqual([
+      cwdA,
+      cwdA,
+      cwdA,
+      cwdB,
+      cwdC,
+    ]);
+    expect(reboundCwds).toEqual([cwdA, cwdA, cwdB, cwdC]);
+
+    await runtime.dispose();
+  });
+});
+
+async function temporaryDirectory(): Promise<string> {
+  const path = await mkdtemp(join(tmpdir(), 'felan-tui-runtime-'));
+  temporaryPaths.push(path);
+  return path;
+}
+
+function completedAssistantMessage(text: string) {
+  return {
+    role: 'assistant' as const,
+    content: [{ type: 'text' as const, text }],
+    api: 'anthropic-messages' as const,
+    provider: 'anthropic',
+    model: 'test-model',
+    usage: {
+      input: 1,
+      output: 1,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 2,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: 'stop' as const,
+    timestamp: Date.now(),
+  };
+}

--- a/apps/tui/test/settings.test.ts
+++ b/apps/tui/test/settings.test.ts
@@ -38,6 +38,13 @@ describe('local settings', () => {
     expect(settings.getSkillPaths()).toEqual([]);
     expect(settings.getPromptTemplatePaths()).toEqual([]);
     expect(settings.getThemePaths()).toEqual([]);
+    expect(settings.getGlobalSettings().packages).toEqual([]);
+    expect(settings.getProjectSettings().packages).toEqual([]);
+
+    await settings.reload();
+
+    expect(settings.getPackages()).toEqual([]);
+    expect(settings.getGlobalSettings().packages).toEqual([]);
   });
 });
 

--- a/apps/tui/test/settings.test.ts
+++ b/apps/tui/test/settings.test.ts
@@ -1,0 +1,48 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createLocalSettingsManager } from '../src/settings.js';
+
+const temporaryPaths: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryPaths.splice(0).map((path) => rm(path, { force: true, recursive: true })));
+});
+
+describe('local settings', () => {
+  it('preserves terminal and model settings while filtering executable resources', async () => {
+    const root = await temporaryDirectory();
+    const cwd = join(root, 'workspace');
+    const agentDir = join(root, 'agent');
+    await mkdir(cwd, { recursive: true });
+    await mkdir(agentDir, { recursive: true });
+    await writeFile(join(agentDir, 'settings.json'), JSON.stringify({
+      quietStartup: true,
+      defaultProvider: 'anthropic',
+      defaultModel: 'test-model',
+      packages: ['npm:untrusted-package'],
+      extensions: ['/tmp/untrusted-extension.ts'],
+      skills: ['/tmp/untrusted-skill'],
+      prompts: ['/tmp/untrusted-prompt'],
+      themes: ['/tmp/untrusted-theme'],
+    }));
+
+    const settings = createLocalSettingsManager(cwd, agentDir);
+
+    expect(settings.getQuietStartup()).toBe(true);
+    expect(settings.getDefaultProvider()).toBe('anthropic');
+    expect(settings.getDefaultModel()).toBe('test-model');
+    expect(settings.getPackages()).toEqual([]);
+    expect(settings.getExtensionPaths()).toEqual([]);
+    expect(settings.getSkillPaths()).toEqual([]);
+    expect(settings.getPromptTemplatePaths()).toEqual([]);
+    expect(settings.getThemePaths()).toEqual([]);
+  });
+});
+
+async function temporaryDirectory(): Promise<string> {
+  const path = await mkdtemp(join(tmpdir(), 'felan-tui-settings-'));
+  temporaryPaths.push(path);
+  return path;
+}

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -5,13 +5,25 @@ trusted publishing and provenance. The workflow has an OIDC identity token and
 contains no npm credential. It packs workspace dependencies with pnpm and uses
 an OIDC-capable npm 11 CLI to publish the resulting tarballs.
 
+The current combined S7-S10 prerelease version is `0.1.0-alpha.2`. The root and
+all five public manifests form one fixed version group. Agent Core diagnostics
+report the same package-derived version.
+
 Before a prerelease:
 
 1. Run `pnpm check:packages` to verify each public package name on npmjs.
-2. Run `pnpm verify` on Node.js 22.20.0.
-3. Confirm every package version is the same prerelease version.
-4. Configure each npm package's trusted publisher for this repository and workflow.
-5. Create the matching `v<version>` tag through the normal reviewed release process.
+2. Run `pnpm check:release` to validate the fixed version group, prerelease tag
+   policy, OIDC provenance, and topological pack/publish order.
+3. Run `pnpm check:proposed-version` to confirm the exact proposed version is
+   unused for every public package. This preparation-only check stays outside
+   `pnpm verify`, so ordinary CI remains valid after publication.
+4. Run `pnpm verify` on Node.js 22.20.0. The packed smoke installs with a clean
+   npm configuration, checks exact workspace dependency versions, imports every
+   public package, and runs the `felan` binary without private credentials.
+5. Configure each npm package's trusted publisher for this repository and workflow.
+6. Create the matching prerelease `v<version>` tag through the normal reviewed
+   release process. The workflow publishes in dependency order: Agent Core,
+   extensions, then TUI, all with the npm `next` dist-tag.
 
 Stable publication follows successful prerelease integration with public host and
 private cloud runtime adapters.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "felan",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "private": true,
   "description": "Portable Felan agent core, extensions, and local TUI",
   "license": "MIT",
@@ -16,6 +16,7 @@
     "test:packed-bin": "node scripts/test-packed-bin.mjs",
     "pack:all": "node scripts/pack.mjs",
     "check:packages": "node scripts/check-package-availability.mjs",
+    "check:proposed-version": "node scripts/check-proposed-version.mjs",
     "check:release": "node scripts/check-release-readiness.mjs",
     "verify": "pnpm check:release && pnpm build && pnpm type-check && pnpm test && pnpm pack:all && pnpm test:packed-bin"
   },

--- a/package.json
+++ b/package.json
@@ -13,10 +13,11 @@
     "build": "pnpm -r --if-present build",
     "type-check": "pnpm -r --if-present type-check",
     "test": "pnpm -r --if-present test",
+    "test:packed-bin": "node scripts/test-packed-bin.mjs",
     "pack:all": "node scripts/pack.mjs",
     "check:packages": "node scripts/check-package-availability.mjs",
     "check:release": "node scripts/check-release-readiness.mjs",
-    "verify": "pnpm check:release && pnpm build && pnpm type-check && pnpm test && pnpm pack:all"
+    "verify": "pnpm check:release && pnpm build && pnpm type-check && pnpm test && pnpm pack:all && pnpm test:packed-bin"
   },
   "devDependencies": {
     "@types/node": "24.12.4",

--- a/packages/agent-core/README.md
+++ b/packages/agent-core/README.md
@@ -28,6 +28,11 @@ typed seam used with Pi's `createAgentSessionRuntime`. Applications retain
 ownership of model credentials, settings, session storage, stream wrappers,
 child-session creation, and presentation listeners.
 
+Every composed session includes `spawn_agent`, which maps portable child-agent
+requests onto `AgentSessionHost.createChildSession`. Applications own child
+execution and can run it locally or delegate it to another runtime without
+changing shared agent behavior.
+
 Applications may pass an explicit `skills` list into session composition.
 Agent Core exposes only that list while project, user, and package skill
 discovery remain disabled.

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felan-ai/agent-core",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "description": "Portable Felan agent contracts and composition",
   "license": "MIT",
   "type": "module",

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -30,7 +30,8 @@
     "prepack": "pnpm build"
   },
   "dependencies": {
-    "@earendil-works/pi-coding-agent": "0.82.1"
+    "@earendil-works/pi-coding-agent": "0.82.1",
+    "typebox": "1.1.38"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/agent-core/src/child-session-tool.ts
+++ b/packages/agent-core/src/child-session-tool.ts
@@ -1,0 +1,54 @@
+import { Type } from 'typebox';
+import type { ToolDefinition } from '@earendil-works/pi-coding-agent';
+import type { AgentChildSessionResult, AgentSessionHost } from './session.js';
+
+const childSessionParameters = Type.Object({
+  personaId: Type.String({ description: 'Persona or role for the child agent' }),
+  prompt: Type.String({ description: 'Task for the child agent' }),
+  block: Type.Optional(Type.Boolean({ description: 'Wait for the child result', default: true })),
+  model: Type.Optional(Type.String({ description: 'Optional provider/model override' })),
+  timeoutMinutes: Type.Optional(Type.Integer({ minimum: 1 })),
+  metadata: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+});
+
+export function createChildSessionTool(
+  host: AgentSessionHost,
+): ToolDefinition<typeof childSessionParameters, AgentChildSessionResult> {
+  return {
+    name: 'spawn_agent',
+    label: 'Spawn Agent',
+    description: 'Spawn a portable child agent through the application host and optionally wait for its result.',
+    promptSnippet: 'Delegate an isolated task to a child agent',
+    promptGuidelines: [
+      'Use spawn_agent when an isolated child agent can handle a self-contained task in parallel or with a separate context.',
+    ],
+    parameters: childSessionParameters,
+    async execute(_toolCallId, params, signal, _onUpdate, context) {
+      if (signal?.aborted) throw new Error('Child session spawn aborted');
+      const sessionId = context.sessionManager.getSessionId();
+      const model = params.model
+        ?? (context.model ? `${context.model.provider}/${context.model.id}` : undefined);
+      const result = await host.createChildSession({
+        rootSessionId: sessionId,
+        parentSessionId: sessionId,
+        personaId: params.personaId,
+        prompt: params.prompt,
+        block: params.block ?? true,
+        ...(model === undefined ? {} : { model }),
+        ...(params.timeoutMinutes === undefined ? {} : { timeoutMinutes: params.timeoutMinutes }),
+        ...(params.metadata === undefined ? {} : { metadata: params.metadata }),
+      });
+      if (!result.ok) {
+        throw new Error(result.error ?? result.message ?? 'Child session failed');
+      }
+
+      const text = result.result
+        ?? result.message
+        ?? `Child session ${result.sessionId} is ${result.status}`;
+      return {
+        content: [{ type: 'text', text }],
+        details: result,
+      };
+    },
+  };
+}

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -4,8 +4,10 @@ export type {
   ExecOptions,
   ExecResult,
 } from './runtime.js';
+export { AGENT_CORE_VERSION } from './version.js';
 export { HostAgentRuntime } from './host-agent-runtime.js';
 export type { HostShellOptions } from './host-agent-runtime.js';
+export { createChildSessionTool } from './child-session-tool.js';
 export {
   bindFelanExtension,
   loadFelanExtensions,

--- a/packages/agent-core/src/session.ts
+++ b/packages/agent-core/src/session.ts
@@ -14,6 +14,7 @@ import {
   type ToolDefinition,
 } from '@earendil-works/pi-coding-agent';
 import { loadFelanExtensions, type ExtensionPackageImporter } from './extensions.js';
+import { createChildSessionTool } from './child-session-tool.js';
 import { createAgentCoreResourceLoader } from './resource-loader.js';
 import type { AgentRuntime } from './runtime.js';
 import { createRuntimeCodingTools } from './tools.js';
@@ -135,8 +136,9 @@ async function composeAgentCoreSession(
       ? {}
       : { appendSystemPrompt: options.appendSystemPrompt }),
   });
-  const customTools = [
+  const customTools: ToolDefinition<any, any, any>[] = [
     ...createRuntimeCodingTools(options.runtime),
+    createChildSessionTool(options.host),
     ...(options.customTools ?? []),
   ];
   const result = await createAgentSession({

--- a/packages/agent-core/src/version.ts
+++ b/packages/agent-core/src/version.ts
@@ -1,0 +1,5 @@
+import { createRequire } from 'node:module';
+
+const packageJson = createRequire(import.meta.url)('../package.json') as { version: string };
+
+export const AGENT_CORE_VERSION = packageJson.version;

--- a/packages/agent-core/test/child-session-tool.test.ts
+++ b/packages/agent-core/test/child-session-tool.test.ts
@@ -1,0 +1,112 @@
+import type { ExtensionContext } from '@earendil-works/pi-coding-agent';
+import { describe, expect, it } from 'vitest';
+import {
+  createChildSessionTool,
+  type AgentChildSessionRequest,
+  type AgentSessionHost,
+} from '../src/index.js';
+
+describe('portable child session tool', () => {
+  it('maps spawn_agent input and session identity onto the host boundary', async () => {
+    const requests: AgentChildSessionRequest[] = [];
+    const host: AgentSessionHost = {
+      createChildSession: async (request) => {
+        requests.push(request);
+        return {
+          ok: true,
+          sessionId: 'child-1',
+          status: 'completed',
+          result: 'child output',
+        };
+      },
+    };
+    const tool = createChildSessionTool(host);
+    const context = {
+      sessionManager: { getSessionId: () => 'parent-1' },
+    } as ExtensionContext;
+
+    const result = await tool.execute(
+      'call-1',
+      {
+        personaId: 'reviewer',
+        prompt: 'Review the change',
+        block: true,
+        model: 'provider/model',
+        timeoutMinutes: 5,
+        metadata: { lane: 'review' },
+      },
+      undefined,
+      undefined,
+      context,
+    );
+
+    expect(requests).toEqual([{
+      rootSessionId: 'parent-1',
+      parentSessionId: 'parent-1',
+      personaId: 'reviewer',
+      prompt: 'Review the change',
+      block: true,
+      model: 'provider/model',
+      timeoutMinutes: 5,
+      metadata: { lane: 'review' },
+    }]);
+    expect(result).toEqual({
+      content: [{ type: 'text', text: 'child output' }],
+      details: {
+        ok: true,
+        sessionId: 'child-1',
+        status: 'completed',
+        result: 'child output',
+      },
+    });
+  });
+
+  it('surfaces host failures as tool errors', async () => {
+    const tool = createChildSessionTool({
+      createChildSession: async () => ({
+        ok: false,
+        sessionId: 'child-2',
+        status: 'failed',
+        error: 'child failed',
+      }),
+    });
+    const context = {
+      sessionManager: { getSessionId: () => 'parent-1' },
+    } as ExtensionContext;
+
+    await expect(tool.execute(
+      'call-2',
+      { personaId: 'worker', prompt: 'Work', block: true },
+      undefined,
+      undefined,
+      context,
+    )).rejects.toThrow('child failed');
+  });
+
+  it('inherits the active parent model when no override is supplied', async () => {
+    const requests: AgentChildSessionRequest[] = [];
+    const tool = createChildSessionTool({
+      createChildSession: async (request) => {
+        requests.push(request);
+        return { ok: true, sessionId: 'child-3', status: 'running' };
+      },
+    });
+    const context = {
+      sessionManager: { getSessionId: () => 'parent-2' },
+      model: { provider: 'anthropic', id: 'claude-test' },
+    } as ExtensionContext;
+
+    await tool.execute(
+      'call-3',
+      { personaId: 'worker', prompt: 'Work', block: false },
+      undefined,
+      undefined,
+      context,
+    );
+
+    expect(requests).toEqual([expect.objectContaining({
+      model: 'anthropic/claude-test',
+      block: false,
+    })]);
+  });
+});

--- a/packages/ext-context/NOTICE
+++ b/packages/ext-context/NOTICE
@@ -1,0 +1,7 @@
+@felan-ai/ext-context
+
+Includes code adapted from pi-progressive-context in the pi-extensions
+repository (git@github.com:mslavov/pi-extensions.git), source commit 9571293.
+
+Copyright (c) 2026 Milko Slavov
+Licensed under the MIT License included in this package.

--- a/packages/ext-context/README.md
+++ b/packages/ext-context/README.md
@@ -1,3 +1,38 @@
 # @felan-ai/ext-context
 
-Package foundation for the Felan progressive-context extension.
+Runtime-portable progressive loading of nested `AGENTS.md` and `CLAUDE.md`
+instructions for Felan sessions.
+
+Felan loads instructions at the session cwd separately. This extension discovers
+instructions below that cwd after the agent successfully reads a file or the user
+submits a decoded CLI `@file` block. It walks from the cwd toward the observed
+file, skips the cwd itself, and loads at most one instruction file per nested
+directory with this precedence:
+
+1. `AGENTS.md`
+2. `CLAUDE.md`
+
+Loaded files are normalized and deduplicated for the session. They are appended
+to each subsequent model context as one hidden `pi-progressive-context` message,
+so the instructions remain available after context compaction. A new session
+clears all discovered and processed paths.
+
+All file access goes through the cwd-contained `AgentRuntime`. Missing or
+unreadable files are nonfatal, and directories already checked during the
+session are not retried. Runtime containment rejects lexical traversal and
+symlink escapes.
+
+Use `/progressive-context` to show the nested instruction files loaded in the
+current session.
+
+## Trigger limitations
+
+- Progressive context affects the model call after a file read or attachment.
+- Images do not expose original filesystem paths through Pi input events.
+- CLI `@file` blocks and successful structured `read` results are supported;
+  shell commands that read files do not emit structured file-read events.
+
+## Attribution
+
+This package adapts the MIT-licensed `pi-progressive-context` implementation.
+See [NOTICE](NOTICE) for source details.

--- a/packages/ext-context/package.json
+++ b/packages/ext-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felan-ai/ext-context",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "description": "Progressive-context extension for Felan",
   "license": "MIT",
   "type": "module",

--- a/packages/ext-context/package.json
+++ b/packages/ext-context/package.json
@@ -8,7 +8,7 @@
   "engines": {
     "node": ">=22.19.0"
   },
-  "files": ["dist", "LICENSE", "README.md"],
+  "files": ["dist", "LICENSE", "NOTICE", "README.md"],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "type-check": "tsc -p tsconfig.json --noEmit",
-    "test": "vitest run --passWithNoTests",
+    "test": "vitest run",
     "prepack": "pnpm build"
   },
   "dependencies": {

--- a/packages/ext-context/src/index.ts
+++ b/packages/ext-context/src/index.ts
@@ -1,3 +1,216 @@
-const contextExtension = (): void => {};
+import type {
+  ExtensionContext,
+  FelanExtension,
+} from '@felan-ai/agent-core';
+import { dirname, isAbsolute, normalize, resolve } from 'node:path';
+
+type ContextFile = {
+  readonly path: string;
+  readonly content: string;
+};
+
+type State = {
+  readonly loadedContextFiles: Map<string, ContextFile>;
+  readonly processedDirs: Set<string>;
+};
+
+const CONTEXT_FILE_CANDIDATES = ['AGENTS.md', 'CLAUDE.md'] as const;
+const CUSTOM_TYPE = 'pi-progressive-context';
+const decoder = new TextDecoder();
+
+const contextExtension: FelanExtension = (pi) => {
+  const state: State = {
+    loadedContextFiles: new Map(),
+    processedDirs: new Set(),
+  };
+
+  pi.on('session_start', (_event, ctx) => {
+    state.loadedContextFiles.clear();
+    state.processedDirs.clear();
+    ctx.ui.setStatus('progressive-context', undefined);
+  });
+
+  pi.on('tool_result', async (event, ctx) => {
+    if (event.toolName !== 'read' || event.isError) return;
+
+    const filePath = typeof event.input.path === 'string' ? event.input.path : undefined;
+    if (!filePath) return;
+
+    await discoverForPath(filePath, ctx, state, pi.runtime.readFile.bind(pi.runtime));
+  });
+
+  pi.on('input', async (event, ctx) => {
+    for (const filePath of parseFileBlockNames(event.text)) {
+      await discoverForPath(filePath, ctx, state, pi.runtime.readFile.bind(pi.runtime));
+    }
+  });
+
+  pi.on('context', (event) => {
+    if (state.loadedContextFiles.size === 0) return;
+
+    return {
+      messages: [
+        ...event.messages,
+        {
+          role: 'custom',
+          customType: CUSTOM_TYPE,
+          content: formatProgressiveContext([...state.loadedContextFiles.values()]),
+          display: false,
+          timestamp: Date.now(),
+        },
+      ],
+    };
+  });
+
+  pi.registerCommand('progressive-context', {
+    description: 'Show progressively loaded nested AGENTS.md / CLAUDE.md files',
+    handler: async (_args, ctx) => {
+      const output = formatLoadedFiles([...state.loadedContextFiles.values()]);
+      if (ctx.hasUI) {
+        ctx.ui.notify(output, 'info');
+      } else {
+        console.error(output);
+      }
+    },
+  });
+};
+
+async function discoverForPath(
+  observedPath: string,
+  ctx: ExtensionContext,
+  state: State,
+  readFile: (path: string) => Promise<Uint8Array>,
+): Promise<void> {
+  const filePath = resolveObservedPath(observedPath, ctx.cwd);
+  if (!filePath) return;
+
+  try {
+    await readFile(filePath);
+  } catch {
+    return;
+  }
+
+  let discovered = false;
+  for (const dir of collectNestedDirs(ctx.cwd, dirname(filePath))) {
+    const dirKey = comparisonPath(dir);
+    if (state.processedDirs.has(dirKey)) continue;
+    state.processedDirs.add(dirKey);
+
+    const contextFile = await loadContextFileFromDir(dir, readFile);
+    if (!contextFile) continue;
+
+    const fileKey = comparisonPath(contextFile.path);
+    if (state.loadedContextFiles.has(fileKey)) continue;
+
+    state.loadedContextFiles.set(fileKey, contextFile);
+    discovered = true;
+  }
+
+  if (discovered) {
+    const count = state.loadedContextFiles.size;
+    ctx.ui.setStatus(
+      'progressive-context',
+      `${count} nested context file${count === 1 ? '' : 's'}`,
+    );
+  }
+}
+
+function resolveObservedPath(observedPath: string, cwd: string): string | undefined {
+  let path = observedPath.trim();
+  if (path.startsWith('@')) path = path.slice(1);
+  if (!path) return undefined;
+
+  const cwdPath = normalize(resolve(cwd));
+  const filePath = normalize(isAbsolute(path) ? resolve(path) : resolve(cwdPath, path));
+
+  return isPathInsideOrEqual(filePath, cwdPath) ? filePath : undefined;
+}
+
+function collectNestedDirs(cwd: string, fileDir: string): string[] {
+  const cwdPath = normalize(resolve(cwd));
+  let current = normalize(resolve(fileDir));
+  const dirs: string[] = [];
+
+  while (comparisonPath(current) !== comparisonPath(cwdPath) && isPathInsideOrEqual(current, cwdPath)) {
+    dirs.push(current);
+    const parent = normalize(dirname(current));
+    if (comparisonPath(parent) === comparisonPath(current)) break;
+    current = parent;
+  }
+
+  return dirs.reverse();
+}
+
+async function loadContextFileFromDir(
+  dir: string,
+  readFile: (path: string) => Promise<Uint8Array>,
+): Promise<ContextFile | undefined> {
+  for (const fileName of CONTEXT_FILE_CANDIDATES) {
+    const filePath = normalize(resolve(dir, fileName));
+    try {
+      return { path: filePath, content: decoder.decode(await readFile(filePath)) };
+    } catch {
+      continue;
+    }
+  }
+}
+
+function isPathInsideOrEqual(path: string, root: string): boolean {
+  const normalizedPath = comparisonPath(path);
+  const normalizedRoot = comparisonPath(root);
+
+  return normalizedPath === normalizedRoot || normalizedPath.startsWith(withTrailingSlash(normalizedRoot));
+}
+
+function comparisonPath(path: string): string {
+  const normalized = normalize(path).replace(/\\/g, '/');
+  return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
+}
+
+function withTrailingSlash(path: string): string {
+  return path.endsWith('/') ? path : `${path}/`;
+}
+
+function parseFileBlockNames(text: string): string[] {
+  const names = new Set<string>();
+  const fileTagPattern = /<file\s+[^>]*\bname=(["'])(.*?)\1[^>]*>/gi;
+  let match: RegExpExecArray | null;
+
+  while ((match = fileTagPattern.exec(text)) !== null) {
+    const name = decodeXmlAttribute(match[2] ?? '').trim();
+    if (name) names.add(name);
+  }
+
+  return [...names];
+}
+
+function decodeXmlAttribute(value: string): string {
+  return value
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&');
+}
+
+function formatProgressiveContext(files: ContextFile[]): string {
+  return [
+    '# Progressive Project Context',
+    '',
+    'The following nested AGENTS.md / CLAUDE.md files became relevant because files under their directories were read or attached. Follow these instructions for work in the corresponding paths.',
+    '',
+    ...files.map((file) => `## ${file.path}\n\n${file.content.trimEnd()}`),
+  ].join('\n');
+}
+
+function formatLoadedFiles(files: ContextFile[]): string {
+  if (files.length === 0) return 'No progressive context files loaded.';
+
+  return [
+    'Progressive Context',
+    `Loaded ${files.length} nested context file${files.length === 1 ? '' : 's'}:`,
+    ...files.map((file) => `- ${file.path}`),
+  ].join('\n');
+}
 
 export default contextExtension;

--- a/packages/ext-context/test/index.test.ts
+++ b/packages/ext-context/test/index.test.ts
@@ -1,0 +1,337 @@
+import { mkdtemp, mkdir, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import type {
+  ExtensionContext,
+  FelanExtensionAPI,
+} from '@felan-ai/agent-core';
+import { HostAgentRuntime } from '@felan-ai/agent-core';
+import { TestAgentRuntime } from '@felan-ai/agent-core/runtime-test-kit';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import contextExtension from '../src/index.js';
+
+type EventHandler = (event: Record<string, unknown>, ctx: ExtensionContext) => unknown;
+type CommandHandler = (args: string, ctx: ExtensionContext) => Promise<void>;
+
+type ContextMessage = {
+  readonly role?: string;
+  readonly customType?: string;
+  readonly content?: string;
+  readonly display?: boolean;
+};
+
+class RecordingRuntime extends TestAgentRuntime {
+  readonly readPaths: string[] = [];
+
+  override async readFile(path: string): Promise<Uint8Array> {
+    this.readPaths.push(path);
+    return super.readFile(path);
+  }
+}
+
+class ExtensionHarness {
+  readonly handlers = new Map<string, EventHandler[]>();
+  readonly commands = new Map<string, CommandHandler>();
+  readonly statuses: Array<[string, string | undefined]> = [];
+  readonly notifications: Array<[string, string]> = [];
+  readonly ctx: ExtensionContext;
+
+  private constructor(readonly runtime: TestAgentRuntime | HostAgentRuntime, cwd: string) {
+    const ui = {
+      setStatus: (key: string, value: string | undefined) => this.statuses.push([key, value]),
+      notify: (message: string, level: string) => this.notifications.push([message, level]),
+    };
+    this.ctx = {
+      cwd,
+      hasUI: true,
+      ui,
+    } as unknown as ExtensionContext;
+  }
+
+  static async create(
+    runtime: TestAgentRuntime | HostAgentRuntime = new TestAgentRuntime('/workspace'),
+  ): Promise<ExtensionHarness> {
+    const harness = new ExtensionHarness(runtime, runtime.cwd);
+    const pi = {
+      runtime,
+      on: (event: string, handler: EventHandler) => {
+        const handlers = harness.handlers.get(event) ?? [];
+        handlers.push(handler);
+        harness.handlers.set(event, handlers);
+      },
+      registerCommand: (name: string, command: { handler: CommandHandler }) => {
+        harness.commands.set(name, command.handler);
+      },
+    } as unknown as FelanExtensionAPI;
+    await contextExtension(pi);
+    return harness;
+  }
+
+  async emit(type: string, event: Record<string, unknown> = {}): Promise<unknown[]> {
+    const results = [];
+    for (const handler of this.handlers.get(type) ?? []) {
+      results.push(await handler({ type, ...event }, this.ctx));
+    }
+    return results;
+  }
+
+  async successfulRead(path: string): Promise<void> {
+    await this.emit('tool_result', {
+      toolName: 'read',
+      toolCallId: 'read-call',
+      input: { path },
+      content: [],
+      details: undefined,
+      isError: false,
+    });
+  }
+
+  async input(text: string): Promise<void> {
+    await this.emit('input', { text, source: 'interactive' });
+  }
+
+  async context(messages: ContextMessage[] = []): Promise<ContextMessage[]> {
+    const [result] = await this.emit('context', { messages });
+    return (result as { messages?: ContextMessage[] } | undefined)?.messages ?? messages;
+  }
+
+  async runCommand(): Promise<void> {
+    const command = this.commands.get('progressive-context');
+    if (!command) throw new Error('progressive-context command was not registered');
+    await command('', this.ctx);
+  }
+}
+
+const temporaryPaths: string[] = [];
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(temporaryPaths.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+});
+
+describe('@felan-ai/ext-context', () => {
+  it('injects newly discovered instructions only on the next context event and resets on session start', async () => {
+    const runtime = new TestAgentRuntime('/workspace');
+    await put(runtime, 'nested/AGENTS.md', 'Nested instructions');
+    await put(runtime, 'nested/file.ts', 'export {};');
+    const harness = await ExtensionHarness.create(runtime);
+    const original = [{ role: 'user', content: 'before read' }];
+
+    expect(await harness.context(original)).toBe(original);
+    await harness.successfulRead('nested/file.ts');
+
+    const messages = await harness.context(original);
+    expect(messages).toHaveLength(2);
+    expect(messages[0]).toBe(original[0]);
+    expect(messages[1]).toMatchObject({
+      role: 'custom',
+      customType: 'pi-progressive-context',
+      display: false,
+    });
+    expect(messages[1]?.content).toContain('Nested instructions');
+    expect(harness.statuses.at(-1)).toEqual(['progressive-context', '1 nested context file']);
+
+    await harness.emit('session_start', { reason: 'new' });
+
+    expect(await harness.context(original)).toBe(original);
+    expect(harness.statuses.at(-1)).toEqual(['progressive-context', undefined]);
+
+    await harness.successfulRead('nested/file.ts');
+    expect((await harness.context(original)).at(-1)?.content).toContain('Nested instructions');
+  });
+
+  it('ignores failed and non-read tool results', async () => {
+    const runtime = new TestAgentRuntime('/workspace');
+    await put(runtime, 'nested/AGENTS.md', 'Nested instructions');
+    await put(runtime, 'nested/file.ts', 'export {};');
+    const harness = await ExtensionHarness.create(runtime);
+
+    await harness.emit('tool_result', {
+      toolName: 'read',
+      input: { path: 'nested/file.ts' },
+      isError: true,
+    });
+    await harness.emit('tool_result', {
+      toolName: 'write',
+      input: { path: 'nested/file.ts' },
+      isError: false,
+    });
+
+    expect(await harness.context()).toEqual([]);
+  });
+
+  it('decodes CLI file block names and accepts the leading @ form', async () => {
+    const runtime = new TestAgentRuntime('/workspace');
+    await put(runtime, 'nested/AGENTS.md', 'Ampersand path instructions');
+    await put(runtime, 'nested/a&b.ts', 'export {};');
+    const harness = await ExtensionHarness.create(runtime);
+
+    await harness.input('<file source="cli" name="@nested/a&amp;b.ts">contents</file>');
+
+    expect((await harness.context()).at(-1)?.content).toContain('Ampersand path instructions');
+  });
+
+  it('walks nested directories in cwd-to-file order while skipping cwd instructions', async () => {
+    const runtime = new TestAgentRuntime('/workspace');
+    await put(runtime, 'AGENTS.md', 'Cwd instructions');
+    await put(runtime, 'one/AGENTS.md', 'One instructions');
+    await put(runtime, 'one/two/CLAUDE.md', 'Two instructions');
+    await put(runtime, 'one/two/file.ts', 'export {};');
+    const harness = await ExtensionHarness.create(runtime);
+
+    await harness.successfulRead('one/two/file.ts');
+
+    const content = (await harness.context()).at(-1)?.content ?? '';
+    expect(content).not.toContain('Cwd instructions');
+    expect(content.indexOf('One instructions')).toBeLessThan(content.indexOf('Two instructions'));
+  });
+
+  it('loads at most one file per directory with AGENTS.md precedence', async () => {
+    const runtime = new RecordingRuntime('/workspace');
+    await put(runtime, 'nested/AGENTS.md', 'Agents wins');
+    await put(runtime, 'nested/CLAUDE.md', 'Claude fallback');
+    await put(runtime, 'nested/file.ts', 'export {};');
+    const harness = await ExtensionHarness.create(runtime);
+
+    await harness.successfulRead('nested/file.ts');
+
+    const content = (await harness.context()).at(-1)?.content ?? '';
+    expect(content).toContain('Agents wins');
+    expect(content).not.toContain('Claude fallback');
+    expect(runtime.readPaths).not.toContain(resolve('/workspace/nested/CLAUDE.md'));
+  });
+
+  it('uses CLAUDE.md as the fallback and decodes bytes with TextDecoder', async () => {
+    const runtime = new TestAgentRuntime('/workspace');
+    await runtime.mkdir('nested', { recursive: true });
+    await runtime.writeFile('nested/CLAUDE.md', new Uint8Array([0x66, 0x6f, 0x80]));
+    await runtime.writeFile('nested/file.ts', new TextEncoder().encode('export {};'));
+    const harness = await ExtensionHarness.create(runtime);
+
+    await harness.successfulRead('nested/file.ts');
+
+    expect((await harness.context()).at(-1)?.content).toContain('fo�');
+  });
+
+  it('deduplicates normalized observed paths and loaded files for the session', async () => {
+    const runtime = new RecordingRuntime('/workspace');
+    await put(runtime, 'nested/deep/AGENTS.md', 'Deep instructions');
+    await put(runtime, 'nested/deep/file.ts', 'export {};');
+    const harness = await ExtensionHarness.create(runtime);
+
+    await harness.successfulRead('nested/./deep/../deep/file.ts');
+    await harness.successfulRead('/workspace/nested/deep/file.ts');
+
+    const content = (await harness.context()).at(-1)?.content ?? '';
+    expect(content.match(/Deep instructions/g)).toHaveLength(1);
+    expect(runtime.readPaths.filter((path) => path === resolve('/workspace/nested/deep/AGENTS.md'))).toHaveLength(1);
+  });
+
+  it('rejects lexical traversal and absolute paths outside the session cwd', async () => {
+    const runtime = new RecordingRuntime('/workspace');
+    const harness = await ExtensionHarness.create(runtime);
+
+    await harness.input('<file name="../outside/file.ts">outside</file>');
+    await harness.successfulRead('/outside/file.ts');
+
+    expect(await harness.context()).toEqual([]);
+    expect(runtime.readPaths).toEqual([]);
+  });
+
+  it('rejects symlink escapes before loading instructions from an apparent parent', async () => {
+    const runtime = new TestAgentRuntime('/workspace');
+    await put(runtime, 'scope/AGENTS.md', 'Must not escape');
+    runtime.addSymlink('scope/escape', '/outside');
+    const harness = await ExtensionHarness.create(runtime);
+
+    await harness.input('<file name="scope/escape/file.ts">outside</file>');
+
+    expect(await harness.context()).toEqual([]);
+  });
+
+  it('treats read failures as nonfatal and never retries processed directories', async () => {
+    const runtime = new RecordingRuntime('/workspace');
+    await put(runtime, 'nested/first.ts', 'first');
+    await put(runtime, 'nested/second.ts', 'second');
+    const harness = await ExtensionHarness.create(runtime);
+
+    await expect(harness.successfulRead('nested/first.ts')).resolves.toBeUndefined();
+    await put(runtime, 'nested/AGENTS.md', 'Added after first check');
+    await harness.successfulRead('nested/second.ts');
+
+    expect(await harness.context()).toEqual([]);
+    expect(runtime.readPaths.filter((path) => path === resolve('/workspace/nested/AGENTS.md'))).toHaveLength(1);
+    expect(runtime.readPaths.filter((path) => path === resolve('/workspace/nested/CLAUDE.md'))).toHaveLength(1);
+  });
+
+  it('retains discovered state across compaction', async () => {
+    const runtime = new TestAgentRuntime('/workspace');
+    await put(runtime, 'nested/AGENTS.md', 'Persistent instructions');
+    await put(runtime, 'nested/file.ts', 'export {};');
+    const harness = await ExtensionHarness.create(runtime);
+    await harness.successfulRead('nested/file.ts');
+
+    await harness.emit('session_compact', { summary: 'compacted state' });
+    const messages = await harness.context([{ role: 'user', content: 'compaction summary' }]);
+
+    expect(messages.at(-1)).toMatchObject({
+      customType: 'pi-progressive-context',
+      content: expect.stringContaining('Persistent instructions'),
+    });
+  });
+
+  it('reports empty and loaded state through /progressive-context', async () => {
+    const runtime = new TestAgentRuntime('/workspace');
+    await put(runtime, 'nested/AGENTS.md', 'Nested instructions');
+    await put(runtime, 'nested/file.ts', 'export {};');
+    const harness = await ExtensionHarness.create(runtime);
+
+    await harness.runCommand();
+    expect(harness.notifications.at(-1)).toEqual(['No progressive context files loaded.', 'info']);
+
+    await harness.successfulRead('nested/file.ts');
+    await harness.runCommand();
+    expect(harness.notifications.at(-1)?.[0]).toContain('/workspace/nested/AGENTS.md');
+  });
+
+  it.each(['host', 'daytona'] as const)('has identical behavior for %s runtime kind', async (kind) => {
+    const runtime = new TestAgentRuntime('/workspace', { kind });
+    await put(runtime, 'nested/AGENTS.md', 'Portable instructions');
+    await put(runtime, 'nested/file.ts', 'export {};');
+    const harness = await ExtensionHarness.create(runtime);
+
+    await harness.successfulRead('nested/file.ts');
+
+    expect((await harness.context()).at(-1)).toMatchObject({
+      customType: 'pi-progressive-context',
+      content: expect.stringContaining('Portable instructions'),
+    });
+  });
+
+  it('relies on HostAgentRuntime containment for real filesystem symlink escapes', async () => {
+    const root = await temporaryDirectory();
+    const workspace = join(root, 'workspace');
+    const outside = join(root, 'outside');
+    await mkdir(join(workspace, 'scope'), { recursive: true });
+    await mkdir(outside, { recursive: true });
+    await writeFile(join(workspace, 'scope', 'AGENTS.md'), 'Must remain unloaded');
+    await writeFile(join(outside, 'file.ts'), 'outside');
+    await symlink(outside, join(workspace, 'scope', 'escape'), process.platform === 'win32' ? 'junction' : 'dir');
+    const harness = await ExtensionHarness.create(new HostAgentRuntime(workspace));
+
+    await harness.successfulRead('scope/escape/file.ts');
+
+    expect(await harness.context()).toEqual([]);
+  });
+});
+
+async function put(runtime: TestAgentRuntime, path: string, content: string): Promise<void> {
+  await runtime.mkdir(dirname(path), { recursive: true });
+  await runtime.writeFile(path, new TextEncoder().encode(content));
+}
+
+async function temporaryDirectory(): Promise<string> {
+  const path = await mkdtemp(join(tmpdir(), 'felan-context-'));
+  temporaryPaths.push(path);
+  return path;
+}

--- a/packages/ext-context/tsconfig.json
+++ b/packages/ext-context/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": { "noEmit": true },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "test/**/*.ts"]
 }

--- a/packages/ext-powerline/NOTICE
+++ b/packages/ext-powerline/NOTICE
@@ -1,0 +1,10 @@
+@felan-ai/ext-powerline
+
+Portions of this package are adapted from the MIT-licensed pi-powerline source
+by Milko Slavov.
+
+The pi-powerline source credits marckrenn/pi-sub packages/sub-core, licensed
+under the MIT License, for subscription provider and usage logic. Felan does
+not include the credential loading or subscription network implementation.
+
+All adaptations remain available under the MIT License in LICENSE.

--- a/packages/ext-powerline/README.md
+++ b/packages/ext-powerline/README.md
@@ -1,3 +1,58 @@
 # @felan-ai/ext-powerline
 
-Package foundation for the Felan terminal powerline extension.
+Default local TUI footer extension for Felan, targeting Pi 0.82.1.
+
+The footer displays:
+
+- current directory
+- cached Git branch, revision, working-tree status, tag, age, stash, upstream, and repository name
+- active model and thinking level
+- session token and cost totals
+- context-window usage
+- statuses published by other Pi extensions
+
+Rendering is ANSI-width-aware and supports left/right alignment, wrapping,
+`minimal`, `powerline`, and `capsule` styles, plus text and Powerline Unicode
+charsets. Git probes are asynchronous, cached, coalesced, time-bounded, and
+executed exclusively through `pi.exec`.
+
+The extension installs its footer on `session_start` only when `ctx.mode` is
+`tui`, redraws for model, thinking, agent, turn, tool, compaction, tree, and Git
+branch changes, and removes and disposes the footer on `session_shutdown`.
+Headless Pi modes perform no footer or Git work.
+
+## Display flags
+
+Configuration is inert for the process lifetime. These Pi flags are read when
+the TUI footer is installed:
+
+| Flag | Supported values | Default |
+| --- | --- | --- |
+| `--felan-powerline-theme` | `dark`, `light`, `nord`, `tokyo-night`, `rose-pine`, `gruvbox` | `dark` |
+| `--felan-powerline-style` | `minimal`, `powerline`, `capsule` | `powerline` |
+| `--felan-powerline-charset` | `text`, `unicode` | `text` |
+| `--felan-powerline-color` | `auto`, `none`, `ansi`, `ansi256`, `truecolor` | `auto` |
+| `--felan-powerline-wrap` | boolean | `true` |
+| `--felan-powerline-directory-style` | `full`, `fish`, `basename` | `fish` |
+| `--felan-powerline-session-type` | `tokens`, `cost`, `both`, `breakdown` | `tokens` |
+| `--felan-powerline-context-style` | `text`, `bar`, `blocks`, `blocks-line`, `dots` | `bar` |
+
+The portable subset does not read or watch configuration files, inspect private
+authentication files or JWTs, call subscription services, or depend on tmux or
+private environment conventions.
+
+## Development
+
+```sh
+pnpm --filter @felan-ai/ext-powerline build
+pnpm --filter @felan-ai/ext-powerline type-check
+pnpm --filter @felan-ai/ext-powerline test
+```
+
+## Attribution
+
+The rendering, theme, segment, lifecycle, and Git-cache design is adapted from
+the MIT-licensed `pi-powerline` source by Milko Slavov. That source credits the
+MIT-licensed `marckrenn/pi-sub` `packages/sub-core` for subscription provider
+and usage logic. Felan excludes that credential and network functionality.
+See [NOTICE](NOTICE).

--- a/packages/ext-powerline/package.json
+++ b/packages/ext-powerline/package.json
@@ -8,7 +8,7 @@
   "engines": {
     "node": ">=22.19.0"
   },
-  "files": ["dist", "LICENSE", "README.md"],
+  "files": ["dist", "LICENSE", "NOTICE", "README.md"],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -22,6 +22,7 @@
     "prepack": "pnpm build"
   },
   "dependencies": {
+    "@earendil-works/pi-tui": "0.82.1",
     "@felan-ai/agent-core": "workspace:*"
   },
   "publishConfig": {

--- a/packages/ext-powerline/package.json
+++ b/packages/ext-powerline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felan-ai/ext-powerline",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "description": "Terminal powerline extension for Felan",
   "license": "MIT",
   "type": "module",

--- a/packages/ext-powerline/src/colors.ts
+++ b/packages/ext-powerline/src/colors.ts
@@ -1,0 +1,138 @@
+import type { ColorCompatibility, PowerlineConfig, ThemeColorKey } from './config.js';
+
+export type ColorMode = 'none' | 'ansi' | 'ansi256' | 'truecolor';
+
+export interface ColorPair {
+  fg: string;
+  bg: string;
+}
+
+export interface ThemePalette {
+  colors: Record<ThemeColorKey, ColorPair>;
+}
+
+const THEMES: Record<PowerlineConfig['theme'], ThemePalette> = {
+  dark: makeTheme({
+    directory: ['#f8fafc', '#2563eb'], git: ['#052e16', '#22c55e'], model: ['#ffffff', '#7c3aed'],
+    session: ['#111827', '#f59e0b'], context: ['#ecfeff', '#0891b2'], status: ['#f8fafc', '#334155'],
+    warning: ['#111827', '#fbbf24'], critical: ['#ffffff', '#dc2626'], muted: ['#cbd5e1', '#1f2937'],
+    extensionStatus1: ['#cbd5e1', '#1f2937'], extensionStatus2: ['#bfdbfe', '#1e3a5f'],
+    extensionStatus3: ['#ddd6fe', '#3b2f5f'], extensionStatus4: ['#99f6e4', '#134e4a'],
+  }),
+  light: makeTheme({
+    directory: ['#ffffff', '#1d4ed8'], git: ['#052e16', '#86efac'], model: ['#ffffff', '#6d28d9'],
+    session: ['#451a03', '#fcd34d'], context: ['#083344', '#67e8f9'], status: ['#111827', '#e5e7eb'],
+    warning: ['#451a03', '#fde68a'], critical: ['#ffffff', '#ef4444'], muted: ['#374151', '#e5e7eb'],
+    extensionStatus1: ['#374151', '#e5e7eb'], extensionStatus2: ['#1e3a8a', '#dbeafe'],
+    extensionStatus3: ['#581c87', '#ede9fe'], extensionStatus4: ['#134e4a', '#ccfbf1'],
+  }),
+  nord: makeTheme({
+    directory: ['#eceff4', '#5e81ac'], git: ['#2e3440', '#a3be8c'], model: ['#2e3440', '#b48ead'],
+    session: ['#2e3440', '#ebcb8b'], context: ['#2e3440', '#88c0d0'], status: ['#d8dee9', '#434c5e'],
+    warning: ['#2e3440', '#ebcb8b'], critical: ['#eceff4', '#bf616a'], muted: ['#d8dee9', '#3b4252'],
+    extensionStatus1: ['#d8dee9', '#3b4252'], extensionStatus2: ['#d8dee9', '#434c5e'],
+    extensionStatus3: ['#2e3440', '#8fbcbb'], extensionStatus4: ['#2e3440', '#81a1c1'],
+  }),
+  'tokyo-night': makeTheme({
+    directory: ['#c0caf5', '#2f7dc8'], git: ['#1a1b26', '#9ece6a'], model: ['#c0caf5', '#7aa2f7'],
+    session: ['#1a1b26', '#e0af68'], context: ['#1a1b26', '#7dcfff'], status: ['#c0caf5', '#24283b'],
+    warning: ['#1a1b26', '#e0af68'], critical: ['#c0caf5', '#f7768e'], muted: ['#a9b1d6', '#1f2335'],
+    extensionStatus1: ['#a9b1d6', '#1f2335'], extensionStatus2: ['#c0caf5', '#24283b'],
+    extensionStatus3: ['#1a1b26', '#7aa2f7'], extensionStatus4: ['#1a1b26', '#73daca'],
+  }),
+  'rose-pine': makeTheme({
+    directory: ['#e0def4', '#31748f'], git: ['#191724', '#9ccfd8'], model: ['#e0def4', '#c4a7e7'],
+    session: ['#191724', '#f6c177'], context: ['#191724', '#ebbcba'], status: ['#e0def4', '#26233a'],
+    warning: ['#191724', '#f6c177'], critical: ['#e0def4', '#eb6f92'], muted: ['#908caa', '#21202e'],
+    extensionStatus1: ['#908caa', '#21202e'], extensionStatus2: ['#e0def4', '#26233a'],
+    extensionStatus3: ['#191724', '#9ccfd8'], extensionStatus4: ['#191724', '#c4a7e7'],
+  }),
+  gruvbox: makeTheme({
+    directory: ['#fbf1c7', '#458588'], git: ['#282828', '#98971a'], model: ['#fbf1c7', '#b16286'],
+    session: ['#282828', '#d79921'], context: ['#282828', '#83a598'], status: ['#ebdbb2', '#3c3836'],
+    warning: ['#282828', '#fabd2f'], critical: ['#fbf1c7', '#cc241d'], muted: ['#d5c4a1', '#3c3836'],
+    extensionStatus1: ['#d5c4a1', '#3c3836'], extensionStatus2: ['#ebdbb2', '#504945'],
+    extensionStatus3: ['#282828', '#83a598'], extensionStatus4: ['#282828', '#8ec07c'],
+  }),
+};
+
+export function resolveColorMode(compatibility: ColorCompatibility): ColorMode {
+  if (compatibility !== 'auto') return compatibility;
+  if (process.env.NO_COLOR || process.env.TERM === 'dumb' || process.env.FORCE_COLOR === '0') return 'none';
+  const colorTerm = (process.env.COLORTERM ?? '').toLowerCase();
+  if (colorTerm.includes('truecolor') || colorTerm.includes('24bit')) return 'truecolor';
+  if ((process.env.TERM ?? '').includes('256color')) return 'ansi256';
+  return 'ansi';
+}
+
+export function getThemePalette(config: PowerlineConfig): ThemePalette {
+  return THEMES[config.theme];
+}
+
+export function colorBlock(text: string, pair: ColorPair, mode: ColorMode): string {
+  return applyAnsi(text, mode, pair.fg, pair.bg);
+}
+
+export function colorForeground(text: string, color: string, mode: ColorMode): string {
+  return applyAnsi(text, mode, color);
+}
+
+export function colorPairText(text: string, pair: ColorPair, mode: ColorMode): string {
+  return applyAnsi(text, mode, pair.fg);
+}
+
+function makeTheme(colors: Record<ThemeColorKey, [fg: string, bg: string]>): ThemePalette {
+  return { colors: Object.fromEntries(Object.entries(colors).map(([key, [fg, bg]]) => [key, { fg, bg }])) as Record<ThemeColorKey, ColorPair> };
+}
+
+function applyAnsi(text: string, mode: ColorMode, fg?: string, bg?: string): string {
+  if (mode === 'none') return text;
+  const codes = [fg ? colorCode(fg, false, mode) : '', bg ? colorCode(bg, true, mode) : ''].filter(Boolean);
+  return codes.length > 0 ? `\x1b[${codes.join(';')}m${text}\x1b[0m` : text;
+}
+
+function colorCode(hex: string, background: boolean, mode: Exclude<ColorMode, 'none'>): string {
+  const rgb = hexToRgb(hex);
+  if (mode === 'truecolor') return `${background ? 48 : 38};2;${rgb.r};${rgb.g};${rgb.b}`;
+  if (mode === 'ansi256') return `${background ? 48 : 38};5;${rgbToAnsi256(rgb.r, rgb.g, rgb.b)}`;
+  return String(nearestAnsi16(rgb.r, rgb.g, rgb.b, background));
+}
+
+function hexToRgb(hex: string): { r: number; g: number; b: number } {
+  const value = hex.slice(1);
+  return { r: Number.parseInt(value.slice(0, 2), 16), g: Number.parseInt(value.slice(2, 4), 16), b: Number.parseInt(value.slice(4, 6), 16) };
+}
+
+function rgbToAnsi256(r: number, g: number, b: number): number {
+  if (r === g && g === b) {
+    if (r < 8) return 16;
+    if (r > 248) return 231;
+    return Math.round(((r - 8) / 247) * 24) + 232;
+  }
+  return 16 + 36 * Math.round((r / 255) * 5) + 6 * Math.round((g / 255) * 5) + Math.round((b / 255) * 5);
+}
+
+const ANSI16_COLORS = [
+  { rgb: [0, 0, 0], fg: 30, bg: 40 }, { rgb: [128, 0, 0], fg: 31, bg: 41 },
+  { rgb: [0, 128, 0], fg: 32, bg: 42 }, { rgb: [128, 128, 0], fg: 33, bg: 43 },
+  { rgb: [0, 0, 128], fg: 34, bg: 44 }, { rgb: [128, 0, 128], fg: 35, bg: 45 },
+  { rgb: [0, 128, 128], fg: 36, bg: 46 }, { rgb: [192, 192, 192], fg: 37, bg: 47 },
+  { rgb: [128, 128, 128], fg: 90, bg: 100 }, { rgb: [255, 0, 0], fg: 91, bg: 101 },
+  { rgb: [0, 255, 0], fg: 92, bg: 102 }, { rgb: [255, 255, 0], fg: 93, bg: 103 },
+  { rgb: [0, 0, 255], fg: 94, bg: 104 }, { rgb: [255, 0, 255], fg: 95, bg: 105 },
+  { rgb: [0, 255, 255], fg: 96, bg: 106 }, { rgb: [255, 255, 255], fg: 97, bg: 107 },
+] as const;
+
+function nearestAnsi16(r: number, g: number, b: number, background: boolean): number {
+  let best: { readonly rgb: readonly [number, number, number]; readonly fg: number; readonly bg: number } = ANSI16_COLORS[0];
+  let distance = Number.POSITIVE_INFINITY;
+  for (const candidate of ANSI16_COLORS) {
+    const [red, green, blue] = candidate.rgb;
+    const candidateDistance = (r - red) ** 2 + (g - green) ** 2 + (b - blue) ** 2;
+    if (candidateDistance < distance) {
+      best = candidate;
+      distance = candidateDistance;
+    }
+  }
+  return background ? best.bg : best.fg;
+}

--- a/packages/ext-powerline/src/config.ts
+++ b/packages/ext-powerline/src/config.ts
@@ -1,0 +1,151 @@
+import type { FelanExtensionAPI } from '@felan-ai/agent-core';
+
+export type ThemeName = 'dark' | 'light' | 'nord' | 'tokyo-night' | 'rose-pine' | 'gruvbox';
+export type FooterStyle = 'minimal' | 'powerline' | 'capsule';
+export type Charset = 'unicode' | 'text';
+export type ColorCompatibility = 'auto' | 'none' | 'ansi' | 'ansi256' | 'truecolor';
+export type DirectoryStyle = 'full' | 'fish' | 'basename';
+export type SessionDisplayType = 'cost' | 'tokens' | 'both' | 'breakdown';
+export type ContextDisplayStyle = 'text' | 'bar' | 'blocks' | 'blocks-line' | 'dots';
+export type SegmentAlignment = 'left' | 'right';
+export type SegmentName = 'directory' | 'git' | 'model' | 'session' | 'context' | 'status';
+export type ThemeColorKey = SegmentName | 'warning' | 'critical' | 'muted' | 'extensionStatus1' | 'extensionStatus2' | 'extensionStatus3' | 'extensionStatus4';
+
+export interface SegmentConfig {
+  enabled: boolean;
+  align?: SegmentAlignment;
+  style?: DirectoryStyle;
+  showSha?: boolean;
+  showWorkingTree?: boolean;
+  showTag?: boolean;
+  showTimeSinceCommit?: boolean;
+  showStashCount?: boolean;
+  showUpstream?: boolean;
+  showRepoName?: boolean;
+  type?: SessionDisplayType;
+  displayStyle?: ContextDisplayStyle;
+  showPercentageOnly?: boolean;
+  showTokensOnly?: boolean;
+  width?: number;
+  warningThreshold?: number;
+  criticalThreshold?: number;
+}
+
+export interface DisplayLineConfig {
+  segments: Partial<Record<SegmentName, SegmentConfig>>;
+}
+
+export interface PowerlineConfig {
+  theme: ThemeName;
+  display: {
+    style: FooterStyle;
+    charset: Charset;
+    colorCompatibility: ColorCompatibility;
+    autoWrap: boolean;
+    padding: number;
+    lines: DisplayLineConfig[];
+  };
+}
+
+export const POWERLINE_FLAGS = {
+  theme: 'felan-powerline-theme',
+  style: 'felan-powerline-style',
+  charset: 'felan-powerline-charset',
+  color: 'felan-powerline-color',
+  wrap: 'felan-powerline-wrap',
+  directoryStyle: 'felan-powerline-directory-style',
+  sessionType: 'felan-powerline-session-type',
+  contextStyle: 'felan-powerline-context-style',
+} as const;
+
+const DEFAULT_CONFIG: PowerlineConfig = {
+  theme: 'dark',
+  display: {
+    style: 'powerline',
+    charset: 'text',
+    colorCompatibility: 'auto',
+    autoWrap: true,
+    padding: 1,
+    lines: [
+      {
+        segments: {
+          directory: { enabled: true, style: 'fish' },
+          git: { enabled: true, showSha: true, showWorkingTree: true },
+          model: { enabled: true, align: 'right' },
+        },
+      },
+      {
+        segments: {
+          session: { enabled: true, type: 'tokens' },
+          context: { enabled: true, displayStyle: 'bar' },
+          status: { enabled: true, align: 'right' },
+        },
+      },
+    ],
+  },
+};
+
+const THEMES = new Set<ThemeName>(['dark', 'light', 'nord', 'tokyo-night', 'rose-pine', 'gruvbox']);
+const STYLES = new Set<FooterStyle>(['minimal', 'powerline', 'capsule']);
+const CHARSETS = new Set<Charset>(['unicode', 'text']);
+const COLORS = new Set<ColorCompatibility>(['auto', 'none', 'ansi', 'ansi256', 'truecolor']);
+const DIRECTORY_STYLES = new Set<DirectoryStyle>(['full', 'fish', 'basename']);
+const SESSION_TYPES = new Set<SessionDisplayType>(['cost', 'tokens', 'both', 'breakdown']);
+const CONTEXT_STYLES = new Set<ContextDisplayStyle>(['text', 'bar', 'blocks', 'blocks-line', 'dots']);
+
+export function registerPowerlineFlags(pi: FelanExtensionAPI): void {
+  pi.registerFlag(POWERLINE_FLAGS.theme, { type: 'string', default: DEFAULT_CONFIG.theme, description: 'Powerline color theme' });
+  pi.registerFlag(POWERLINE_FLAGS.style, { type: 'string', default: DEFAULT_CONFIG.display.style, description: 'Powerline footer style' });
+  pi.registerFlag(POWERLINE_FLAGS.charset, { type: 'string', default: DEFAULT_CONFIG.display.charset, description: 'Powerline footer charset' });
+  pi.registerFlag(POWERLINE_FLAGS.color, { type: 'string', default: DEFAULT_CONFIG.display.colorCompatibility, description: 'Powerline ANSI color mode' });
+  pi.registerFlag(POWERLINE_FLAGS.wrap, { type: 'boolean', default: DEFAULT_CONFIG.display.autoWrap, description: 'Wrap long powerline segments' });
+  pi.registerFlag(POWERLINE_FLAGS.directoryStyle, { type: 'string', default: 'fish', description: 'Powerline directory display style' });
+  pi.registerFlag(POWERLINE_FLAGS.sessionType, { type: 'string', default: 'tokens', description: 'Powerline session usage display' });
+  pi.registerFlag(POWERLINE_FLAGS.contextStyle, { type: 'string', default: 'bar', description: 'Powerline context usage display' });
+}
+
+export function configFromFlags(pi: Pick<FelanExtensionAPI, 'getFlag'>): PowerlineConfig {
+  const config = cloneConfig(DEFAULT_CONFIG);
+  config.theme = enumFlag(pi, POWERLINE_FLAGS.theme, THEMES, config.theme);
+  config.display.style = enumFlag(pi, POWERLINE_FLAGS.style, STYLES, config.display.style);
+  config.display.charset = enumFlag(pi, POWERLINE_FLAGS.charset, CHARSETS, config.display.charset);
+  config.display.colorCompatibility = enumFlag(pi, POWERLINE_FLAGS.color, COLORS, config.display.colorCompatibility);
+  config.display.autoWrap = booleanFlag(pi, POWERLINE_FLAGS.wrap, config.display.autoWrap);
+
+  const directory = config.display.lines[0]?.segments.directory;
+  if (directory) directory.style = enumFlag(pi, POWERLINE_FLAGS.directoryStyle, DIRECTORY_STYLES, directory.style ?? 'fish');
+  const session = config.display.lines[1]?.segments.session;
+  if (session) session.type = enumFlag(pi, POWERLINE_FLAGS.sessionType, SESSION_TYPES, session.type ?? 'tokens');
+  const context = config.display.lines[1]?.segments.context;
+  if (context) context.displayStyle = enumFlag(pi, POWERLINE_FLAGS.contextStyle, CONTEXT_STYLES, context.displayStyle ?? 'bar');
+  return config;
+}
+
+function enumFlag<T extends string>(
+  pi: Pick<FelanExtensionAPI, 'getFlag'>,
+  name: string,
+  values: ReadonlySet<T>,
+  fallback: T,
+): T {
+  const value = pi.getFlag(name);
+  return typeof value === 'string' && values.has(value as T) ? value as T : fallback;
+}
+
+function booleanFlag(pi: Pick<FelanExtensionAPI, 'getFlag'>, name: string, fallback: boolean): boolean {
+  const value = pi.getFlag(name);
+  return typeof value === 'boolean' ? value : fallback;
+}
+
+function cloneConfig(config: PowerlineConfig): PowerlineConfig {
+  return {
+    theme: config.theme,
+    display: {
+      ...config.display,
+      lines: config.display.lines.map((line) => ({
+        segments: Object.fromEntries(
+          Object.entries(line.segments).map(([name, segment]) => [name, segment ? { ...segment } : segment]),
+        ),
+      })),
+    },
+  };
+}

--- a/packages/ext-powerline/src/footer.ts
+++ b/packages/ext-powerline/src/footer.ts
@@ -133,7 +133,7 @@ function renderAlignedLine(
   const left = leftAvailable > 0
     ? ensureWidth(renderStyledSegments(leftSegments, config, palette, mode, symbols), leftAvailable)
     : '';
-  if (!left) return right;
+  if (!left) return ' '.repeat(Math.max(0, width - rightWidth)) + right;
   return ensureWidth(left + ' '.repeat(Math.max(1, width - visibleWidth(left) - rightWidth)) + right, width);
 }
 

--- a/packages/ext-powerline/src/footer.ts
+++ b/packages/ext-powerline/src/footer.ts
@@ -1,0 +1,194 @@
+import type { ExtensionContext, FelanExtensionAPI } from '@felan-ai/agent-core';
+import { truncateToWidth, visibleWidth, type Component, type TUI } from '@earendil-works/pi-tui';
+import {
+  colorBlock,
+  colorForeground,
+  colorPairText,
+  getThemePalette,
+  resolveColorMode,
+  type ColorMode,
+  type ThemePalette,
+} from './colors.js';
+import type { PowerlineConfig } from './config.js';
+import { GitCache } from './git.js';
+import { renderSegments, type FooterDataLike, type RenderedSegment } from './segments.js';
+import { getSymbols, type PowerlineSymbols } from './symbols.js';
+
+export interface PowerlineFooterOptions {
+  pi: FelanExtensionAPI;
+  ctx: ExtensionContext;
+  tui: TUI;
+  footerData: FooterDataLike;
+  config: PowerlineConfig;
+}
+
+export class PowerlineFooter implements Component {
+  private readonly gitCache: GitCache;
+  private readonly unsubscribeBranch: () => void;
+  private disposed = false;
+
+  constructor(private readonly options: PowerlineFooterOptions) {
+    this.gitCache = new GitCache(options.pi, options.ctx.cwd);
+    this.unsubscribeBranch = options.footerData.onBranchChange(() => this.invalidate());
+    this.refreshGit();
+  }
+
+  invalidate(): void {
+    this.refreshGit();
+    this.requestRender();
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.unsubscribeBranch();
+    this.gitCache.dispose();
+  }
+
+  render(width: number): string[] {
+    const safeWidth = Math.max(0, Math.floor(width));
+    if (safeWidth === 0) return [''];
+
+    const { config } = this.options;
+    const symbols = getSymbols(config.display.charset);
+    const palette = getThemePalette(config);
+    const mode = resolveColorMode(config.display.colorCompatibility);
+    const lines: string[] = [];
+
+    for (const line of config.display.lines) {
+      const gitDetails = this.gitCache.get();
+      const segments = renderSegments(line, {
+        ctx: this.options.ctx,
+        footerData: this.options.footerData,
+        ...(gitDetails === undefined ? {} : { gitDetails }),
+        symbols,
+      });
+      if (segments.length > 0) lines.push(...renderFooterLine(segments, config, palette, mode, symbols, safeWidth));
+    }
+
+    return (lines.length > 0 ? lines : ['']).map((line) => ensureWidth(line, safeWidth));
+  }
+
+  private refreshGit(): void {
+    void this.gitCache.refresh().then(() => this.requestRender());
+  }
+
+  private requestRender(): void {
+    if (!this.disposed) this.options.tui.requestRender();
+  }
+}
+
+export function renderFooterLine(
+  segments: RenderedSegment[],
+  config: PowerlineConfig,
+  palette: ThemePalette,
+  mode: ColorMode,
+  symbols: PowerlineSymbols,
+  width: number,
+): string[] {
+  const left = segments.filter((segment) => segment.align === 'left');
+  const right = segments.filter((segment) => segment.align === 'right');
+  if (right.length > 0) return [renderAlignedLine(left, right, config, palette, mode, symbols, width)];
+  if (!config.display.autoWrap) return [ensureWidth(renderStyledSegments(segments, config, palette, mode, symbols), width)];
+
+  const lines: string[] = [];
+  let current: RenderedSegment[] = [];
+  for (const segment of segments) {
+    const candidate = [...current, segment];
+    if (current.length > 0 && visibleWidth(renderStyledSegments(candidate, config, palette, mode, symbols)) > width) {
+      lines.push(ensureWidth(renderStyledSegments(current, config, palette, mode, symbols), width));
+      current = [segment];
+    } else {
+      current = candidate;
+    }
+  }
+  if (current.length > 0) lines.push(ensureWidth(renderStyledSegments(current, config, palette, mode, symbols), width));
+  return lines;
+}
+
+export function renderStyledSegments(
+  segments: RenderedSegment[],
+  config: PowerlineConfig,
+  palette: ThemePalette,
+  mode: ColorMode,
+  symbols: PowerlineSymbols,
+): string {
+  if (config.display.style === 'minimal') return renderMinimal(segments, config, palette, mode, symbols);
+  if (config.display.style === 'capsule') return renderCapsule(segments, config, palette, mode, symbols);
+  return renderPowerline(segments, config, palette, mode, symbols);
+}
+
+function renderAlignedLine(
+  leftSegments: RenderedSegment[],
+  rightSegments: RenderedSegment[],
+  config: PowerlineConfig,
+  palette: ThemePalette,
+  mode: ColorMode,
+  symbols: PowerlineSymbols,
+  width: number,
+): string {
+  const right = ensureWidth(renderStyledSegments(rightSegments, config, palette, mode, symbols), width);
+  const rightWidth = visibleWidth(right);
+  const leftAvailable = Math.max(0, width - rightWidth - (leftSegments.length > 0 ? 1 : 0));
+  const left = leftAvailable > 0
+    ? ensureWidth(renderStyledSegments(leftSegments, config, palette, mode, symbols), leftAvailable)
+    : '';
+  if (!left) return right;
+  return ensureWidth(left + ' '.repeat(Math.max(1, width - visibleWidth(left) - rightWidth)) + right, width);
+}
+
+function renderMinimal(
+  segments: RenderedSegment[],
+  config: PowerlineConfig,
+  palette: ThemePalette,
+  mode: ColorMode,
+  symbols: PowerlineSymbols,
+): string {
+  const separator = colorForeground(` ${symbols.separatorThin} `, palette.colors.muted.fg, mode);
+  return segments
+    .map((segment) => colorPairText(pad(segment.text, config.display.padding), palette.colors[segment.colorKey], mode))
+    .join(separator);
+}
+
+function renderPowerline(
+  segments: RenderedSegment[],
+  config: PowerlineConfig,
+  palette: ThemePalette,
+  mode: ColorMode,
+  symbols: PowerlineSymbols,
+): string {
+  let output = '';
+  for (let index = 0; index < segments.length; index += 1) {
+    const segment = segments[index]!;
+    const pair = palette.colors[segment.colorKey];
+    const next = segments[index + 1];
+    output += colorBlock(pad(segment.text, config.display.padding), pair, mode);
+    output += next
+      ? colorBlock(symbols.separator, { fg: pair.bg, bg: palette.colors[next.colorKey].bg }, mode)
+      : colorForeground(symbols.separator, pair.bg, mode);
+  }
+  return output;
+}
+
+function renderCapsule(
+  segments: RenderedSegment[],
+  config: PowerlineConfig,
+  palette: ThemePalette,
+  mode: ColorMode,
+  symbols: PowerlineSymbols,
+): string {
+  return segments.map((segment) => {
+    const pair = palette.colors[segment.colorKey];
+    return colorForeground(symbols.capsuleLeft, pair.bg, mode)
+      + colorBlock(pad(segment.text, config.display.padding), pair, mode)
+      + colorForeground(symbols.capsuleRight, pair.bg, mode);
+  }).join(' ');
+}
+
+function pad(text: string, padding: number): string {
+  return padding > 0 ? `${' '.repeat(padding)}${text}${' '.repeat(padding)}` : text;
+}
+
+function ensureWidth(line: string, width: number): string {
+  return visibleWidth(line) <= width ? line : truncateToWidth(line, width, '…');
+}

--- a/packages/ext-powerline/src/git.ts
+++ b/packages/ext-powerline/src/git.ts
@@ -1,0 +1,176 @@
+import type { FelanExtensionAPI } from '@felan-ai/agent-core';
+
+export interface GitUpstream {
+  name?: string;
+  ahead: number;
+  behind: number;
+}
+
+export interface GitDetails {
+  branch?: string;
+  sha?: string;
+  dirty: boolean;
+  changedFiles: number;
+  tag?: string;
+  timeSinceCommit?: string;
+  stashCount: number;
+  upstream?: GitUpstream;
+  repoName?: string;
+  refreshedAt: number;
+}
+
+export interface ParsedGitStatus {
+  branch?: string;
+  changedFiles: number;
+  stashCount: number;
+  upstream?: GitUpstream;
+}
+
+const GIT_TIMEOUT_MS = 1_200;
+
+export class GitCache {
+  private details: GitDetails | undefined;
+  private inFlight: Promise<void> | undefined;
+  private disposed = false;
+
+  constructor(
+    private readonly pi: Pick<FelanExtensionAPI, 'exec'>,
+    private readonly cwd: string,
+    private readonly now: () => number = Date.now,
+  ) {}
+
+  get(): GitDetails | undefined {
+    return this.details;
+  }
+
+  refresh(): Promise<void> {
+    if (this.disposed) return Promise.resolve();
+    if (this.inFlight) return this.inFlight;
+    this.inFlight = this.refreshNow().finally(() => {
+      this.inFlight = undefined;
+    });
+    return this.inFlight;
+  }
+
+  dispose(): void {
+    this.disposed = true;
+  }
+
+  private async refreshNow(): Promise<void> {
+    const root = await runGit(this.pi, ['rev-parse', '--show-toplevel'], this.cwd);
+    if (this.disposed) return;
+    if (!root) {
+      this.details = undefined;
+      return;
+    }
+
+    const [sha, status, tag, commitTimestamp] = await Promise.all([
+      runGit(this.pi, ['rev-parse', '--short', 'HEAD'], this.cwd),
+      runGit(this.pi, ['status', '--porcelain=v2', '--branch', '--show-stash'], this.cwd),
+      runGit(this.pi, ['describe', '--tags', '--exact-match'], this.cwd),
+      runGit(this.pi, ['log', '-1', '--format=%ct'], this.cwd),
+    ]);
+    if (this.disposed) return;
+
+    const parsed = parseGitStatus(status);
+    const commitSeconds = commitTimestamp === undefined ? undefined : Number.parseInt(commitTimestamp, 10);
+    const timeSinceCommit = commitSeconds === undefined ? undefined : formatAge(commitSeconds, this.now());
+    this.details = {
+      ...(parsed.branch === undefined ? {} : { branch: parsed.branch }),
+      ...(sha === undefined ? {} : { sha }),
+      dirty: parsed.changedFiles > 0,
+      changedFiles: parsed.changedFiles,
+      ...(tag === undefined ? {} : { tag }),
+      ...(timeSinceCommit === undefined ? {} : { timeSinceCommit }),
+      stashCount: parsed.stashCount,
+      ...(parsed.upstream === undefined ? {} : { upstream: parsed.upstream }),
+      repoName: basename(root),
+      refreshedAt: this.now(),
+    };
+  }
+}
+
+export async function runGit(
+  pi: Pick<FelanExtensionAPI, 'exec'>,
+  args: string[],
+  cwd: string,
+): Promise<string | undefined> {
+  try {
+    const result = await pi.exec('git', args, { cwd, timeout: GIT_TIMEOUT_MS });
+    if (result.code !== 0 || result.killed) return undefined;
+    return result.stdout.trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function parseGitStatus(status: string | undefined): ParsedGitStatus {
+  if (!status) return { changedFiles: 0, stashCount: 0 };
+  if (status.split('\n').some((line) => line.startsWith('# branch.'))) return parsePorcelainV2(status);
+  return parsePorcelainV1(status);
+}
+
+export function formatAge(commitUnixSeconds: number, nowMilliseconds = Date.now()): string | undefined {
+  if (!Number.isFinite(commitUnixSeconds)) return undefined;
+  const seconds = Math.max(0, Math.floor(nowMilliseconds / 1_000) - commitUnixSeconds);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 48) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d`;
+  const months = Math.floor(days / 30);
+  return months < 12 ? `${months}mo` : `${Math.floor(months / 12)}y`;
+}
+
+function parsePorcelainV2(status: string): ParsedGitStatus {
+  const lines = status.split('\n').filter(Boolean);
+  const branchValue = headerValue(lines, '# branch.head ');
+  const upstreamName = headerValue(lines, '# branch.upstream ');
+  const aheadBehind = headerValue(lines, '# branch.ab ')?.match(/^\+(\d+) -(\d+)$/);
+  const ahead = Number.parseInt(aheadBehind?.[1] ?? '0', 10);
+  const behind = Number.parseInt(aheadBehind?.[2] ?? '0', 10);
+  const upstream = upstreamName || ahead || behind
+    ? { ...(upstreamName ? { name: upstreamName } : {}), ahead, behind }
+    : undefined;
+  const branch = branchValue === '(detached)' ? 'detached' : branchValue;
+  return {
+    ...(branch ? { branch } : {}),
+    changedFiles: lines.filter((line) => !line.startsWith('#')).length,
+    stashCount: Number.parseInt(headerValue(lines, '# stash ') ?? '0', 10) || 0,
+    ...(upstream === undefined ? {} : { upstream }),
+  };
+}
+
+function parsePorcelainV1(status: string): ParsedGitStatus {
+  const lines = status.split('\n').filter(Boolean);
+  const header = lines.find((line) => line.startsWith('## '));
+  const changedFiles = lines.filter((line) => !line.startsWith('## ')).length;
+  if (!header) return { changedFiles, stashCount: 0 };
+
+  const branchPart = header.slice(3);
+  const upstreamName = branchPart.match(/\.\.\.([^\s\[]+)/)?.[1];
+  const ahead = Number.parseInt(branchPart.match(/ahead (\d+)/)?.[1] ?? '0', 10);
+  const behind = Number.parseInt(branchPart.match(/behind (\d+)/)?.[1] ?? '0', 10);
+  const upstream = upstreamName || ahead || behind
+    ? { ...(upstreamName ? { name: upstreamName } : {}), ahead, behind }
+    : undefined;
+  const rawBranch = branchPart.split('...')[0]?.split(' ')[0]?.trim();
+  const branch = rawBranch === 'HEAD' ? 'detached' : rawBranch;
+  return {
+    ...(branch ? { branch } : {}),
+    changedFiles,
+    stashCount: 0,
+    ...(upstream === undefined ? {} : { upstream }),
+  };
+}
+
+function headerValue(lines: string[], prefix: string): string | undefined {
+  return lines.find((line) => line.startsWith(prefix))?.slice(prefix.length).trim() || undefined;
+}
+
+function basename(path: string): string {
+  const parts = path.replace(/\\/g, '/').split('/').filter(Boolean);
+  return parts.at(-1) ?? path;
+}

--- a/packages/ext-powerline/src/git.ts
+++ b/packages/ext-powerline/src/git.ts
@@ -9,11 +9,11 @@ export interface GitUpstream {
 export interface GitDetails {
   branch?: string;
   sha?: string;
-  dirty: boolean;
-  changedFiles: number;
+  dirty?: boolean;
+  changedFiles?: number;
   tag?: string;
   timeSinceCommit?: string;
-  stashCount: number;
+  stashCount?: number;
   upstream?: GitUpstream;
   repoName?: string;
   refreshedAt: number;
@@ -73,17 +73,28 @@ export class GitCache {
     if (this.disposed) return;
 
     const parsed = parseGitStatus(status);
+    const statusDetails = parsed === undefined
+      ? {
+          ...(this.details?.branch === undefined ? {} : { branch: this.details.branch }),
+          ...(this.details?.dirty === undefined ? {} : { dirty: this.details.dirty }),
+          ...(this.details?.changedFiles === undefined ? {} : { changedFiles: this.details.changedFiles }),
+          ...(this.details?.stashCount === undefined ? {} : { stashCount: this.details.stashCount }),
+          ...(this.details?.upstream === undefined ? {} : { upstream: this.details.upstream }),
+        }
+      : {
+          ...(parsed.branch === undefined ? {} : { branch: parsed.branch }),
+          dirty: parsed.changedFiles > 0,
+          changedFiles: parsed.changedFiles,
+          stashCount: parsed.stashCount,
+          ...(parsed.upstream === undefined ? {} : { upstream: parsed.upstream }),
+        };
     const commitSeconds = commitTimestamp === undefined ? undefined : Number.parseInt(commitTimestamp, 10);
     const timeSinceCommit = commitSeconds === undefined ? undefined : formatAge(commitSeconds, this.now());
     this.details = {
-      ...(parsed.branch === undefined ? {} : { branch: parsed.branch }),
+      ...statusDetails,
       ...(sha === undefined ? {} : { sha }),
-      dirty: parsed.changedFiles > 0,
-      changedFiles: parsed.changedFiles,
       ...(tag === undefined ? {} : { tag }),
       ...(timeSinceCommit === undefined ? {} : { timeSinceCommit }),
-      stashCount: parsed.stashCount,
-      ...(parsed.upstream === undefined ? {} : { upstream: parsed.upstream }),
       repoName: basename(root),
       refreshedAt: this.now(),
     };
@@ -104,8 +115,8 @@ export async function runGit(
   }
 }
 
-export function parseGitStatus(status: string | undefined): ParsedGitStatus {
-  if (!status) return { changedFiles: 0, stashCount: 0 };
+export function parseGitStatus(status: string | undefined): ParsedGitStatus | undefined {
+  if (!status) return undefined;
   if (status.split('\n').some((line) => line.startsWith('# branch.'))) return parsePorcelainV2(status);
   return parsePorcelainV1(status);
 }

--- a/packages/ext-powerline/src/index.ts
+++ b/packages/ext-powerline/src/index.ts
@@ -1,3 +1,44 @@
-const powerlineExtension = (): void => {};
+import type { ExtensionContext, FelanExtension } from '@felan-ai/agent-core';
+import { configFromFlags, registerPowerlineFlags } from './config.js';
+import { PowerlineFooter } from './footer.js';
+
+const powerlineExtension: FelanExtension = (pi) => {
+  let footer: PowerlineFooter | undefined;
+
+  registerPowerlineFlags(pi);
+
+  function installFooter(ctx: ExtensionContext): void {
+    if (ctx.mode !== 'tui') return;
+    footer?.dispose();
+    ctx.ui.setFooter((tui, _theme, footerData) => {
+      footer = new PowerlineFooter({ pi, ctx, tui, footerData, config: configFromFlags(pi) });
+      return footer;
+    });
+  }
+
+  function redraw(): void {
+    footer?.invalidate();
+  }
+
+  pi.on('session_start', (_event, ctx) => installFooter(ctx));
+  pi.on('session_shutdown', (_event, ctx) => {
+    footer?.dispose();
+    footer = undefined;
+    if (ctx.mode === 'tui') ctx.ui.setFooter(undefined);
+  });
+
+  pi.on('agent_start', redraw);
+  pi.on('agent_end', redraw);
+  pi.on('turn_end', redraw);
+  pi.on('tool_execution_end', redraw);
+  pi.on('session_compact', redraw);
+  pi.on('session_tree', redraw);
+  pi.on('model_select', redraw);
+  pi.on('thinking_level_select', redraw);
+};
 
 export default powerlineExtension;
+export { POWERLINE_FLAGS, configFromFlags } from './config.js';
+export { PowerlineFooter, renderFooterLine, renderStyledSegments } from './footer.js';
+export { GitCache, formatAge, parseGitStatus, runGit } from './git.js';
+export { formatTokens, renderSegments, sanitizePlainText } from './segments.js';

--- a/packages/ext-powerline/src/segments.ts
+++ b/packages/ext-powerline/src/segments.ts
@@ -1,0 +1,236 @@
+import type { ExtensionContext } from '@felan-ai/agent-core';
+import type { DisplayLineConfig, SegmentConfig, SegmentName, ThemeColorKey } from './config.js';
+import type { GitDetails } from './git.js';
+import { BAR_LEVELS, type PowerlineSymbols } from './symbols.js';
+
+export interface FooterDataLike {
+  getGitBranch(): string | null;
+  getExtensionStatuses(): ReadonlyMap<string, string>;
+  getAvailableProviderCount(): number;
+  onBranchChange(callback: () => void): () => void;
+}
+
+export interface SegmentRenderContext {
+  ctx: ExtensionContext;
+  footerData: FooterDataLike;
+  gitDetails?: GitDetails;
+  symbols: PowerlineSymbols;
+}
+
+export interface RenderedSegment {
+  name: SegmentName;
+  colorKey: ThemeColorKey;
+  text: string;
+  align: 'left' | 'right';
+}
+
+interface UsageTotals {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  cost: number;
+}
+
+const ANSI_PATTERN = /\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g;
+const EXTENSION_STATUS_COLORS: ThemeColorKey[] = ['extensionStatus1', 'extensionStatus2', 'extensionStatus3', 'extensionStatus4'];
+
+export function renderSegments(line: DisplayLineConfig, context: SegmentRenderContext): RenderedSegment[] {
+  const segments: RenderedSegment[] = [];
+  for (const [name, config] of Object.entries(line.segments) as [SegmentName, SegmentConfig][]) {
+    if (!config.enabled) continue;
+    const rendered = renderSegment(name, config, context);
+    const values = Array.isArray(rendered) ? rendered : rendered ? [rendered] : [];
+    for (const segment of values) {
+      if (segment.text.trim()) segments.push({ ...segment, align: config.align ?? 'left' });
+    }
+  }
+  return segments;
+}
+
+export function sanitizePlainText(value: string): string {
+  return value
+    .replace(ANSI_PATTERN, '')
+    .replace(/[\r\n\t]/g, ' ')
+    .replace(/[\x00-\x1F\x7F]/g, ' ')
+    .replace(/ +/g, ' ')
+    .trim();
+}
+
+export function formatTokens(count: number): string {
+  if (count < 1_000) return String(count);
+  if (count < 10_000) return `${(count / 1_000).toFixed(1)}k`;
+  if (count < 1_000_000) return `${Math.round(count / 1_000)}k`;
+  if (count < 10_000_000) return `${(count / 1_000_000).toFixed(1)}M`;
+  return `${Math.round(count / 1_000_000)}M`;
+}
+
+function renderSegment(
+  name: SegmentName,
+  config: SegmentConfig,
+  context: SegmentRenderContext,
+): Omit<RenderedSegment, 'align'> | Omit<RenderedSegment, 'align'>[] | undefined {
+  switch (name) {
+    case 'directory': return renderDirectory(config, context);
+    case 'git': return renderGit(config, context);
+    case 'model': return renderModel(context);
+    case 'session': return renderSession(config, context);
+    case 'context': return renderContext(config, context);
+    case 'status': return renderStatus(context);
+  }
+}
+
+function renderDirectory(config: SegmentConfig, context: SegmentRenderContext): Omit<RenderedSegment, 'align'> {
+  const style = config.style ?? 'fish';
+  const cwd = context.ctx.cwd;
+  const text = style === 'basename' ? basename(cwd) : style === 'full' ? cwd : fishPath(cwd);
+  return { name: 'directory', colorKey: 'directory', text: sanitizePlainText(text) };
+}
+
+function renderGit(config: SegmentConfig, context: SegmentRenderContext): Omit<RenderedSegment, 'align'> | undefined {
+  const details = context.gitDetails;
+  const branch = sanitizePlainText(context.footerData.getGitBranch() ?? details?.branch ?? '');
+  const parts: string[] = [];
+  if (config.showRepoName && details?.repoName) parts.push(sanitizePlainText(details.repoName));
+  if (branch) parts.push(formatWithOptionalSymbol(context.symbols.branch, branch));
+  if (config.showSha && details?.sha) parts.push(formatWithOptionalSymbol(context.symbols.sha, sanitizePlainText(details.sha)));
+  if (config.showWorkingTree && details) {
+    const workingTree = formatWorkingTree(details, context.symbols);
+    if (workingTree) parts.push(workingTree);
+  }
+  if (config.showTag && details?.tag) parts.push(`${context.symbols.tag} ${sanitizePlainText(details.tag)}`);
+  if (config.showTimeSinceCommit && details?.timeSinceCommit) parts.push(`${context.symbols.clock} ${details.timeSinceCommit}`.trim());
+  if (config.showStashCount && details?.stashCount) parts.push(`${context.symbols.stash} ${details.stashCount}`);
+  if (config.showUpstream && details?.upstream) {
+    const upstream: string[] = [];
+    if (details.upstream.name) upstream.push(sanitizePlainText(details.upstream.name));
+    if (details.upstream.ahead) upstream.push(`${context.symbols.ahead}${details.upstream.ahead}`);
+    if (details.upstream.behind) upstream.push(`${context.symbols.behind}${details.upstream.behind}`);
+    if (upstream.length > 0) parts.push(upstream.join(' '));
+  }
+  return parts.length > 0 ? { name: 'git', colorKey: 'git', text: parts.join(' ') } : undefined;
+}
+
+function renderModel(context: SegmentRenderContext): Omit<RenderedSegment, 'align'> {
+  const model = context.ctx.model;
+  let text = model?.id ?? 'no-model';
+  if (model && context.footerData.getAvailableProviderCount() > 1) text = `(${model.provider}) ${text}`;
+  if (model?.reasoning && context.ctx.thinkingLevel) text = `${text} • ${context.ctx.thinkingLevel}`;
+  return { name: 'model', colorKey: 'model', text: sanitizePlainText(text) };
+}
+
+function renderSession(config: SegmentConfig, context: SegmentRenderContext): Omit<RenderedSegment, 'align'> {
+  const totals = getUsageTotals(context.ctx);
+  const tokenText = `${context.symbols.tokensIn}${formatTokens(totals.input)} ${context.symbols.tokensOut}${formatTokens(totals.output)}`;
+  const cacheText = `${context.symbols.cacheRead}${formatTokens(totals.cacheRead)} ${context.symbols.cacheWrite}${formatTokens(totals.cacheWrite)}`;
+  const costText = `$${totals.cost.toFixed(3)}`;
+  const type = config.type ?? 'tokens';
+  const text = type === 'cost'
+    ? costText
+    : type === 'both'
+      ? `${tokenText} ${costText}`
+      : type === 'breakdown'
+        ? `${tokenText} ${cacheText} ${costText}`
+        : tokenText;
+  return { name: 'session', colorKey: 'session', text };
+}
+
+function renderContext(config: SegmentConfig, context: SegmentRenderContext): Omit<RenderedSegment, 'align'> | undefined {
+  const usage = context.ctx.getContextUsage();
+  const contextWindow = usage?.contextWindow ?? context.ctx.model?.contextWindow;
+  if (!contextWindow) return undefined;
+
+  const percent = usage?.percent ?? null;
+  const tokens = usage?.tokens ?? null;
+  const percentText = percent === null ? '?' : `${percent.toFixed(1)}%`;
+  const ratio = percent === null ? 0 : clamp(percent / 100, 0, 1);
+  const width = config.width ?? 10;
+  const usageText = tokens === null ? `?/${formatTokens(contextWindow)}` : `${formatTokens(tokens)}/${formatTokens(contextWindow)}`;
+  const style = config.displayStyle ?? 'bar';
+
+  let text: string;
+  if (config.showTokensOnly) text = `ctx ${usageText}`;
+  else if (config.showPercentageOnly) text = `ctx ${percentText}`;
+  else if (style === 'text') text = `ctx ${usageText} ${percentText}`;
+  else if (style === 'dots') text = `ctx ${percentText} ${repeatProgress(context.symbols.dotFull, context.symbols.dotEmpty, ratio, width)}`;
+  else if (style === 'blocks-line') text = renderBlockLine(ratio, width, context.symbols);
+  else if (style === 'blocks') text = `ctx ${percentText} ${renderBlockLine(ratio, width, context.symbols)}`;
+  else text = `ctx ${percentText} ${repeatProgress(context.symbols.blockFull, context.symbols.blockEmpty, ratio, width)}`;
+
+  const warning = config.warningThreshold ?? 70;
+  const critical = config.criticalThreshold ?? 90;
+  const colorKey: ThemeColorKey = percent !== null && percent >= critical
+    ? 'critical'
+    : percent !== null && percent >= warning ? 'warning' : 'context';
+  return { name: 'context', colorKey, text };
+}
+
+function renderStatus(context: SegmentRenderContext): Omit<RenderedSegment, 'align'>[] | undefined {
+  const statuses = [...context.footerData.getExtensionStatuses().entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([, text]) => sanitizePlainText(text))
+    .filter(Boolean);
+  return statuses.length === 0 ? undefined : statuses.map((text, index) => ({
+    name: 'status',
+    colorKey: EXTENSION_STATUS_COLORS[index % EXTENSION_STATUS_COLORS.length]!,
+    text,
+  }));
+}
+
+function getUsageTotals(context: ExtensionContext): UsageTotals {
+  const totals: UsageTotals = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0 };
+  for (const entry of context.sessionManager.getEntries()) {
+    if (entry.type !== 'message' || entry.message.role !== 'assistant') continue;
+    totals.input += entry.message.usage.input;
+    totals.output += entry.message.usage.output;
+    totals.cacheRead += entry.message.usage.cacheRead;
+    totals.cacheWrite += entry.message.usage.cacheWrite;
+    totals.cost += entry.message.usage.cost.total;
+  }
+  return totals;
+}
+
+function basename(path: string): string {
+  const parts = path.replace(/\\/g, '/').split('/').filter(Boolean);
+  return parts.at(-1) ?? path;
+}
+
+function fishPath(path: string): string {
+  const normalized = path.replace(/\\/g, '/');
+  if (!normalized.includes('/')) return normalized;
+  const prefix = normalized.startsWith('/') ? '/' : '';
+  const parts = normalized.replace(/^\//, '').split('/').filter(Boolean);
+  if (parts.length <= 1) return `${prefix}${parts.join('/')}`;
+  return `${prefix}${[...parts.slice(0, -1).map((part) => part[0] ?? part), parts.at(-1)].join('/')}`;
+}
+
+function formatWithOptionalSymbol(symbol: string, text: string): string {
+  return symbol ? `${symbol} ${text}` : text;
+}
+
+function formatWorkingTree(details: GitDetails, symbols: PowerlineSymbols): string | undefined {
+  if (!details.dirty) return symbols.clean || undefined;
+  if (details.changedFiles > 0) return symbols.dirty ? `${symbols.dirty} ${details.changedFiles}` : String(details.changedFiles);
+  return symbols.dirty || undefined;
+}
+
+function repeatProgress(full: string, empty: string, ratio: number, width: number): string {
+  const filled = Math.round(width * ratio);
+  return `${full.repeat(filled)}${empty.repeat(Math.max(0, width - filled))}`;
+}
+
+function renderBlockLine(ratio: number, width: number, symbols: PowerlineSymbols): string {
+  if (width <= 0) return '';
+  if (symbols.blockFull !== '█') return repeatProgress(symbols.blockFull, symbols.blockEmpty, ratio, width);
+  const exact = ratio * width;
+  const fullBlocks = Math.floor(exact);
+  const remainder = exact - fullBlocks;
+  const partial = remainder > 0 && fullBlocks < width
+    ? BAR_LEVELS[Math.max(0, Math.ceil(remainder * BAR_LEVELS.length) - 1)]
+    : '';
+  return `${symbols.blockFull.repeat(fullBlocks)}${partial}${symbols.blockEmpty.repeat(Math.max(0, width - fullBlocks - (partial ? 1 : 0)))}`;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}

--- a/packages/ext-powerline/src/segments.ts
+++ b/packages/ext-powerline/src/segments.ts
@@ -209,8 +209,11 @@ function formatWithOptionalSymbol(symbol: string, text: string): string {
 }
 
 function formatWorkingTree(details: GitDetails, symbols: PowerlineSymbols): string | undefined {
+  if (details.dirty === undefined) return undefined;
   if (!details.dirty) return symbols.clean || undefined;
-  if (details.changedFiles > 0) return symbols.dirty ? `${symbols.dirty} ${details.changedFiles}` : String(details.changedFiles);
+  if (details.changedFiles !== undefined && details.changedFiles > 0) {
+    return symbols.dirty ? `${symbols.dirty} ${details.changedFiles}` : String(details.changedFiles);
+  }
   return symbols.dirty || undefined;
 }
 

--- a/packages/ext-powerline/src/symbols.ts
+++ b/packages/ext-powerline/src/symbols.ts
@@ -1,0 +1,45 @@
+import type { Charset } from './config.js';
+
+export interface PowerlineSymbols {
+  separator: string;
+  separatorThin: string;
+  capsuleLeft: string;
+  capsuleRight: string;
+  branch: string;
+  sha: string;
+  clean: string;
+  dirty: string;
+  ahead: string;
+  behind: string;
+  stash: string;
+  tag: string;
+  clock: string;
+  tokensIn: string;
+  tokensOut: string;
+  cacheRead: string;
+  cacheWrite: string;
+  dotFull: string;
+  dotEmpty: string;
+  blockFull: string;
+  blockEmpty: string;
+}
+
+export const BAR_LEVELS = ['▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'];
+
+const unicodeSymbols: PowerlineSymbols = {
+  separator: '', separatorThin: '', capsuleLeft: '', capsuleRight: '',
+  branch: '', sha: '◌', clean: '✓', dirty: '✗', ahead: '↑', behind: '↓',
+  stash: '≡', tag: '⌑', clock: '◷', tokensIn: '↑', tokensOut: '↓', cacheRead: 'R',
+  cacheWrite: 'W', dotFull: '●', dotEmpty: '○', blockFull: '█', blockEmpty: '░',
+};
+
+const textSymbols: PowerlineSymbols = {
+  separator: ' ', separatorThin: '|', capsuleLeft: '[', capsuleRight: ']',
+  branch: '', sha: 'sha:', clean: '', dirty: '', ahead: 'ahead', behind: 'behind',
+  stash: 'stash', tag: 'tag:', clock: '', tokensIn: 'in', tokensOut: 'out', cacheRead: 'R',
+  cacheWrite: 'W', dotFull: '*', dotEmpty: '.', blockFull: '#', blockEmpty: '-',
+};
+
+export function getSymbols(charset: Charset): PowerlineSymbols {
+  return charset === 'text' ? textSymbols : unicodeSymbols;
+}

--- a/packages/ext-powerline/test/config.test.ts
+++ b/packages/ext-powerline/test/config.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { POWERLINE_FLAGS, configFromFlags, registerPowerlineFlags } from '../src/config.js';
+
+describe('powerline flags', () => {
+  it('registers only namespaced inert display flags', () => {
+    const registered = new Map<string, unknown>();
+    registerPowerlineFlags({
+      registerFlag: (name: string, options: unknown) => registered.set(name, options),
+    } as never);
+
+    expect([...registered.keys()]).toEqual(Object.values(POWERLINE_FLAGS));
+    expect([...registered.keys()].every((name) => name.startsWith('felan-powerline-'))).toBe(true);
+    expect(registered.get(POWERLINE_FLAGS.wrap)).toMatchObject({ type: 'boolean', default: true });
+  });
+
+  it('applies supported values and falls back for invalid values', () => {
+    const values = new Map<string, boolean | string>([
+      [POWERLINE_FLAGS.theme, 'nord'],
+      [POWERLINE_FLAGS.style, 'capsule'],
+      [POWERLINE_FLAGS.charset, 'unicode'],
+      [POWERLINE_FLAGS.color, 'none'],
+      [POWERLINE_FLAGS.wrap, false],
+      [POWERLINE_FLAGS.directoryStyle, 'basename'],
+      [POWERLINE_FLAGS.sessionType, 'both'],
+      [POWERLINE_FLAGS.contextStyle, 'dots'],
+    ]);
+    const config = configFromFlags({ getFlag: (name) => values.get(name) });
+    expect(config).toMatchObject({
+      theme: 'nord',
+      display: { style: 'capsule', charset: 'unicode', colorCompatibility: 'none', autoWrap: false },
+    });
+    expect(config.display.lines[0]?.segments.directory?.style).toBe('basename');
+    expect(config.display.lines[1]?.segments.session?.type).toBe('both');
+    expect(config.display.lines[1]?.segments.context?.displayStyle).toBe('dots');
+
+    const fallback = configFromFlags({ getFlag: () => 'unsupported' });
+    expect(fallback).toMatchObject({
+      theme: 'dark',
+      display: { style: 'powerline', charset: 'text', colorCompatibility: 'auto', autoWrap: true },
+    });
+  });
+});

--- a/packages/ext-powerline/test/git.test.ts
+++ b/packages/ext-powerline/test/git.test.ts
@@ -1,0 +1,108 @@
+import type { FelanExtensionAPI } from '@felan-ai/agent-core';
+import { describe, expect, it, vi } from 'vitest';
+import { GitCache, formatAge, parseGitStatus, runGit } from '../src/git.js';
+
+describe('Git status parsing', () => {
+  it('parses porcelain v2 branch, upstream, stash, and working tree state', () => {
+    expect(parseGitStatus([
+      '# branch.oid abcdef',
+      '# branch.head story-10',
+      '# branch.upstream origin/story-10',
+      '# branch.ab +2 -3',
+      '# stash 4',
+      '1 .M N... 100644 100644 100644 abc abc file.ts',
+      '? new.ts',
+    ].join('\n'))).toEqual({
+      branch: 'story-10',
+      changedFiles: 2,
+      stashCount: 4,
+      upstream: { name: 'origin/story-10', ahead: 2, behind: 3 },
+    });
+  });
+
+  it('parses detached and legacy porcelain status and handles empty output', () => {
+    expect(parseGitStatus('# branch.oid abc\n# branch.head (detached)')).toEqual({
+      branch: 'detached', changedFiles: 0, stashCount: 0,
+    });
+    expect(parseGitStatus('## main...origin/main [ahead 1, behind 2]\n M one\n?? two')).toEqual({
+      branch: 'main',
+      changedFiles: 2,
+      stashCount: 0,
+      upstream: { name: 'origin/main', ahead: 1, behind: 2 },
+    });
+    expect(parseGitStatus(undefined)).toEqual({ changedFiles: 0, stashCount: 0 });
+  });
+
+  it('formats commit age boundaries', () => {
+    const now = 10_000_000_000;
+    expect(formatAge(now / 1_000 - 59, now)).toBe('59s');
+    expect(formatAge(now / 1_000 - 60 * 30, now)).toBe('30m');
+    expect(formatAge(now / 1_000 - 60 * 60 * 3, now)).toBe('3h');
+    expect(formatAge(Number.NaN, now)).toBeUndefined();
+  });
+});
+
+describe('Git execution and cache', () => {
+  it('uses pi.exec with a timeout and suppresses exit, kill, and thrown failures', async () => {
+    const success = vi.fn().mockResolvedValue({ stdout: ' main \n', stderr: '', code: 0, killed: false });
+    await expect(runGit({ exec: success } as never, ['branch', '--show-current'], '/workspace')).resolves.toBe('main');
+    expect(success).toHaveBeenCalledWith('git', ['branch', '--show-current'], { cwd: '/workspace', timeout: 1_200 });
+
+    for (const result of [
+      { stdout: 'ignored', stderr: 'bad', code: 1, killed: false },
+      { stdout: 'ignored', stderr: '', code: 0, killed: true },
+    ]) {
+      await expect(runGit({ exec: vi.fn().mockResolvedValue(result) } as never, ['status'], '/workspace')).resolves.toBeUndefined();
+    }
+    await expect(runGit({ exec: vi.fn().mockRejectedValue(new Error('missing git')) } as never, ['status'], '/workspace')).resolves.toBeUndefined();
+  });
+
+  it('coalesces refreshes and caches parsed repository details', async () => {
+    const exec = vi.fn(async (_command: string, args: string[]) => {
+      const key = args.join(' ');
+      const stdout = new Map([
+        ['rev-parse --show-toplevel', '/workspace/repo'],
+        ['rev-parse --short HEAD', 'abc123'],
+        ['status --porcelain=v2 --branch --show-stash', '# branch.oid abc123\n# branch.head main\n# branch.upstream origin/main\n# branch.ab +1 -0\n# stash 2\n? new.ts'],
+        ['describe --tags --exact-match', 'v1.0.0'],
+        ['log -1 --format=%ct', '9990'],
+      ]).get(key);
+      return { stdout: stdout ?? '', stderr: '', code: 0, killed: false };
+    });
+    const cache = new GitCache({ exec } as unknown as Pick<FelanExtensionAPI, 'exec'>, '/workspace/repo', () => 10_000_000);
+
+    await Promise.all([cache.refresh(), cache.refresh(), cache.refresh()]);
+
+    expect(exec).toHaveBeenCalledTimes(5);
+    expect(cache.get()).toEqual({
+      branch: 'main', sha: 'abc123', dirty: true, changedFiles: 1, tag: 'v1.0.0', timeSinceCommit: '10s',
+      stashCount: 2, upstream: { name: 'origin/main', ahead: 1, behind: 0 }, repoName: 'repo', refreshedAt: 10_000_000,
+    });
+  });
+
+  it('clears cached details when the repository probe fails and ignores late results after disposal', async () => {
+    let rootAvailable = true;
+    let release!: () => void;
+    const blocked = new Promise<void>((resolve) => { release = resolve; });
+    const exec = vi.fn(async (_command: string, args: string[]) => {
+      const key = args.join(' ');
+      if (key === 'rev-parse --show-toplevel') {
+        if (!rootAvailable) return { stdout: '', stderr: 'not a repo', code: 128, killed: false };
+        return { stdout: '/repo', stderr: '', code: 0, killed: false };
+      }
+      await blocked;
+      return { stdout: '', stderr: '', code: 0, killed: false };
+    });
+    const cache = new GitCache({ exec } as unknown as Pick<FelanExtensionAPI, 'exec'>, '/repo');
+    const refresh = cache.refresh();
+    cache.dispose();
+    release();
+    await refresh;
+    expect(cache.get()).toBeUndefined();
+
+    const failed = new GitCache({ exec } as unknown as Pick<FelanExtensionAPI, 'exec'>, '/repo');
+    rootAvailable = false;
+    await expect(failed.refresh()).resolves.toBeUndefined();
+    expect(failed.get()).toBeUndefined();
+  });
+});

--- a/packages/ext-powerline/test/git.test.ts
+++ b/packages/ext-powerline/test/git.test.ts
@@ -30,7 +30,7 @@ describe('Git status parsing', () => {
       stashCount: 0,
       upstream: { name: 'origin/main', ahead: 1, behind: 2 },
     });
-    expect(parseGitStatus(undefined)).toEqual({ changedFiles: 0, stashCount: 0 });
+    expect(parseGitStatus(undefined)).toBeUndefined();
   });
 
   it('formats commit age boundaries', () => {
@@ -78,6 +78,66 @@ describe('Git execution and cache', () => {
       branch: 'main', sha: 'abc123', dirty: true, changedFiles: 1, tag: 'v1.0.0', timeSinceCommit: '10s',
       stashCount: 2, upstream: { name: 'origin/main', ahead: 1, behind: 0 }, repoName: 'repo', refreshedAt: 10_000_000,
     });
+  });
+
+  it('retains cached status details when later status probes fail or time out', async () => {
+    let statusAttempt = 0;
+    const exec = vi.fn(async (_command: string, args: string[]) => {
+      const key = args.join(' ');
+      if (key === 'status --porcelain=v2 --branch --show-stash') {
+        statusAttempt += 1;
+        if (statusAttempt === 2) return { stdout: '', stderr: 'failed', code: 1, killed: false };
+        if (statusAttempt === 3) return { stdout: '', stderr: '', code: 0, killed: true };
+        return {
+          stdout: '# branch.oid abc123\n# branch.head main\n# branch.upstream origin/main\n# branch.ab +1 -2\n# stash 3\n? new.ts',
+          stderr: '',
+          code: 0,
+          killed: false,
+        };
+      }
+      const stdout = new Map([
+        ['rev-parse --show-toplevel', '/workspace/repo'],
+        ['rev-parse --short HEAD', 'abc123'],
+      ]).get(key);
+      return { stdout: stdout ?? '', stderr: '', code: 0, killed: false };
+    });
+    let now = 1;
+    const cache = new GitCache(
+      { exec } as unknown as Pick<FelanExtensionAPI, 'exec'>,
+      '/workspace/repo',
+      () => now,
+    );
+
+    await cache.refresh();
+    const expectedStatus = {
+      branch: 'main', dirty: true, changedFiles: 1, stashCount: 3,
+      upstream: { name: 'origin/main', ahead: 1, behind: 2 },
+    };
+    expect(cache.get()).toMatchObject(expectedStatus);
+
+    now = 2;
+    await cache.refresh();
+    expect(cache.get()).toMatchObject({ ...expectedStatus, refreshedAt: 2 });
+
+    now = 3;
+    await cache.refresh();
+    expect(cache.get()).toMatchObject({ ...expectedStatus, refreshedAt: 3 });
+  });
+
+  it('omits status details when the initial status probe is unavailable', async () => {
+    const exec = vi.fn(async (_command: string, args: string[]) => {
+      const key = args.join(' ');
+      if (key === 'status --porcelain=v2 --branch --show-stash') {
+        return { stdout: '', stderr: '', code: 0, killed: true };
+      }
+      const stdout = key === 'rev-parse --show-toplevel' ? '/workspace/repo' : '';
+      return { stdout, stderr: '', code: 0, killed: false };
+    });
+    const cache = new GitCache({ exec } as unknown as Pick<FelanExtensionAPI, 'exec'>, '/workspace/repo', () => 1);
+
+    await cache.refresh();
+
+    expect(cache.get()).toEqual({ repoName: 'repo', refreshedAt: 1 });
   });
 
   it('clears cached details when the repository probe fails and ignores late results after disposal', async () => {

--- a/packages/ext-powerline/test/lifecycle.test.ts
+++ b/packages/ext-powerline/test/lifecycle.test.ts
@@ -1,0 +1,122 @@
+import type { ExtensionContext, FelanExtensionAPI } from '@felan-ai/agent-core';
+import type { Component, TUI } from '@earendil-works/pi-tui';
+import { describe, expect, it, vi } from 'vitest';
+import powerlineExtension from '../src/index.js';
+import type { FooterDataLike } from '../src/segments.js';
+
+describe('powerline lifecycle', () => {
+  it.each(['rpc', 'json', 'print'] as const)('is headless-safe in %s mode', async (mode) => {
+    const harness = extensionHarness();
+    powerlineExtension(harness.pi);
+    const ctx = extensionContext(mode);
+
+    await harness.emit('session_start', {}, ctx.value);
+    await harness.emit('agent_start', {}, ctx.value);
+    await harness.emit('session_shutdown', {}, ctx.value);
+
+    expect(ctx.setFooter).not.toHaveBeenCalled();
+    expect(harness.exec).not.toHaveBeenCalled();
+  });
+
+  it('installs on session start, redraws on relevant events, and disposes on shutdown', async () => {
+    const harness = extensionHarness();
+    powerlineExtension(harness.pi);
+    const ctx = extensionContext('tui');
+
+    await harness.emit('session_start', {}, ctx.value);
+    expect(ctx.setFooter).toHaveBeenCalledTimes(1);
+    const factory = ctx.setFooter.mock.calls[0]![0] as (tui: TUI, theme: unknown, data: FooterDataLike) => Component & { dispose(): void };
+    const requestRender = vi.fn();
+    let branchChange: (() => void) | undefined;
+    const unsubscribe = vi.fn();
+    const footerData: FooterDataLike = {
+      getGitBranch: () => 'main',
+      getExtensionStatuses: () => new Map(),
+      getAvailableProviderCount: () => 1,
+      onBranchChange: (callback) => {
+        branchChange = callback;
+        return unsubscribe;
+      },
+    };
+    const footer = factory({ requestRender } as unknown as TUI, {}, footerData);
+    await settle();
+    const initialRenders = requestRender.mock.calls.length;
+
+    for (const event of [
+      'agent_start', 'agent_end', 'turn_end', 'tool_execution_end',
+      'session_compact', 'session_tree', 'model_select', 'thinking_level_select',
+    ]) {
+      await harness.emit(event, {}, ctx.value);
+    }
+    branchChange?.();
+    expect(requestRender.mock.calls.length).toBeGreaterThan(initialRenders + 8);
+
+    await harness.emit('session_shutdown', {}, ctx.value);
+    expect(unsubscribe).toHaveBeenCalledOnce();
+    expect(ctx.setFooter).toHaveBeenLastCalledWith(undefined);
+    const afterShutdown = requestRender.mock.calls.length;
+    branchChange?.();
+    await harness.emit('agent_start', {}, ctx.value);
+    await settle();
+    expect(requestRender).toHaveBeenCalledTimes(afterShutdown);
+
+    footer.dispose();
+    expect(unsubscribe).toHaveBeenCalledOnce();
+  });
+
+  it('registers lifecycle handlers and all namespaced flags at initialization', () => {
+    const harness = extensionHarness();
+    powerlineExtension(harness.pi);
+    expect([...harness.handlers.keys()]).toEqual(expect.arrayContaining([
+      'session_start', 'session_shutdown', 'agent_start', 'agent_end', 'turn_end',
+      'tool_execution_end', 'session_compact', 'session_tree', 'model_select', 'thinking_level_select',
+    ]));
+    expect([...harness.flags.keys()]).toHaveLength(8);
+    expect([...harness.flags.keys()].every((flag) => flag.startsWith('felan-powerline-'))).toBe(true);
+  });
+});
+
+function extensionHarness() {
+  const handlers = new Map<string, Array<(...args: any[]) => unknown>>();
+  const flags = new Map<string, { default?: boolean | string }>();
+  const exec = vi.fn().mockResolvedValue({ stdout: '', stderr: '', code: 128, killed: false });
+  const pi = {
+    on: (event: string, handler: (...args: any[]) => unknown) => {
+      const current = handlers.get(event) ?? [];
+      current.push(handler);
+      handlers.set(event, current);
+    },
+    registerFlag: (name: string, options: { default?: boolean | string }) => flags.set(name, options),
+    getFlag: (name: string) => flags.get(name)?.default,
+    exec,
+    runtime: {},
+  } as unknown as FelanExtensionAPI;
+  return {
+    pi,
+    handlers,
+    flags,
+    exec,
+    emit: async (event: string, ...args: unknown[]) => {
+      for (const handler of handlers.get(event) ?? []) await handler(...args);
+    },
+  };
+}
+
+function extensionContext(mode: ExtensionContext['mode']) {
+  const setFooter = vi.fn();
+  const value = {
+    mode,
+    hasUI: mode === 'tui' || mode === 'rpc',
+    cwd: '/workspace',
+    ui: { setFooter },
+    model: undefined,
+    thinkingLevel: 'off',
+    getContextUsage: () => undefined,
+    sessionManager: { getEntries: () => [] },
+  } as unknown as ExtensionContext;
+  return { value, setFooter };
+}
+
+async function settle(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}

--- a/packages/ext-powerline/test/rendering.test.ts
+++ b/packages/ext-powerline/test/rendering.test.ts
@@ -1,0 +1,211 @@
+import type { ExtensionContext } from '@felan-ai/agent-core';
+import { visibleWidth } from '@earendil-works/pi-tui';
+import { describe, expect, it } from 'vitest';
+import { getThemePalette } from '../src/colors.js';
+import { configFromFlags, type PowerlineConfig, type SegmentName } from '../src/config.js';
+import { renderFooterLine, renderStyledSegments } from '../src/footer.js';
+import { renderSegments, sanitizePlainText, type FooterDataLike, type RenderedSegment } from '../src/segments.js';
+import { getSymbols } from '../src/symbols.js';
+
+describe('powerline rendering', () => {
+  it('renders minimal, powerline, and capsule styles with both charsets', () => {
+    const segments = [segment('directory', 'one'), segment('git', 'two')];
+    const expected = {
+      minimal: 'one | two',
+      powerline: 'one two ',
+      capsule: '[one] [two]',
+    } as const;
+
+    for (const style of ['minimal', 'powerline', 'capsule'] as const) {
+      const config = testConfig({ style, charset: 'text', padding: 0 });
+      expect(renderStyledSegments(segments, config, getThemePalette(config), 'none', getSymbols('text'))).toBe(expected[style]);
+    }
+
+    const unicode = testConfig({ style: 'powerline', charset: 'unicode', padding: 0 });
+    expect(renderStyledSegments(segments, unicode, getThemePalette(unicode), 'none', getSymbols('unicode'))).toBe('onetwo');
+  });
+
+  it('measures ANSI-colored content by visible width and truncates safely', () => {
+    const config = testConfig({ style: 'powerline', charset: 'unicode', padding: 1, autoWrap: false });
+    const lines = renderFooterLine(
+      [segment('directory', '界界界界')],
+      config,
+      getThemePalette(config),
+      'truecolor',
+      getSymbols('unicode'),
+      7,
+    );
+
+    expect(lines[0]).toContain('\x1b[');
+    expect(visibleWidth(lines[0]!)).toBeLessThanOrEqual(7);
+    expect(sanitizePlainText(lines[0]!)).not.toContain('\x1b');
+  });
+
+  it('wraps whole left segments and keeps a right group at the terminal edge', () => {
+    const wrapping = testConfig({ style: 'minimal', padding: 0, autoWrap: true });
+    const wrapped = renderFooterLine(
+      [segment('directory', 'alpha'), segment('git', 'bravo')],
+      wrapping,
+      getThemePalette(wrapping),
+      'none',
+      getSymbols('text'),
+      8,
+    );
+    expect(wrapped).toEqual(['alpha', 'bravo']);
+
+    const aligned = testConfig({ style: 'minimal', padding: 0 });
+    const [line] = renderFooterLine(
+      [segment('directory', 'left'), segment('model', 'right', 'right')],
+      aligned,
+      getThemePalette(aligned),
+      'none',
+      getSymbols('text'),
+      20,
+    );
+    expect(line).toBe('left           right');
+    expect(visibleWidth(line!)).toBe(20);
+  });
+});
+
+describe('powerline segments', () => {
+  it('formats full, fish, and basename directory paths without host-home assumptions', () => {
+    expect(renderSingle('directory', { enabled: true, style: 'full' }, context({ cwd: '/work/alpha/project' })).text).toBe('/work/alpha/project');
+    expect(renderSingle('directory', { enabled: true, style: 'fish' }, context({ cwd: '/work/alpha/project' })).text).toBe('/w/a/project');
+    expect(renderSingle('directory', { enabled: true, style: 'basename' }, context({ cwd: '/work/alpha/project' })).text).toBe('project');
+  });
+
+  it('renders model provider and thinking level when relevant', () => {
+    const rendered = renderSingle('model', { enabled: true }, context({
+      model: { id: 'model-x', provider: 'provider-x', reasoning: true, contextWindow: 100_000 },
+      thinkingLevel: 'high',
+      providerCount: 2,
+    }));
+    expect(rendered.text).toBe('(provider-x) model-x • high');
+  });
+
+  it('totals session tokens, cache usage, and cost', () => {
+    const rendered = renderSingle('session', { enabled: true, type: 'breakdown' }, context({
+      entries: [
+        assistantEntry(1_200, 300, 400, 50, 0.1234),
+        { type: 'message', message: { role: 'user', content: 'ignored' } },
+        assistantEntry(800, 700, 100, 50, 0.1),
+      ],
+    }));
+    expect(rendered.text).toBe('in2.0k out1.0k R500 W100 $0.223');
+  });
+
+  it('renders context variants and threshold colors', () => {
+    const warning = renderSingle('context', {
+      enabled: true,
+      displayStyle: 'bar',
+      width: 4,
+      warningThreshold: 60,
+      criticalThreshold: 90,
+    }, context({ contextUsage: { tokens: 70_000, contextWindow: 100_000, percent: 70 } }));
+    expect(warning).toMatchObject({ colorKey: 'warning', text: 'ctx 70.0% ###-' });
+
+    const critical = renderSingle('context', {
+      enabled: true,
+      displayStyle: 'text',
+      criticalThreshold: 90,
+    }, context({ contextUsage: { tokens: 95_000, contextWindow: 100_000, percent: 95 } }));
+    expect(critical).toMatchObject({ colorKey: 'critical', text: 'ctx 95k/100k 95.0%' });
+
+    const unknown = renderSingle('context', {
+      enabled: true,
+      displayStyle: 'dots',
+      width: 3,
+    }, context({ contextUsage: { tokens: null, contextWindow: 100_000, percent: null } }));
+    expect(unknown.text).toBe('ctx ? ...');
+  });
+
+  it('uses cached Git details, footer branch state, and sorted sanitized statuses', () => {
+    const ctx = context({
+      branch: 'footer-main',
+      statuses: new Map([
+        ['z', '\x1b[31mbad\x1b[0m\nline'],
+        ['a', 'ready'],
+      ]),
+    });
+    const git = renderSingle('git', {
+      enabled: true,
+      showSha: true,
+      showWorkingTree: true,
+      showRepoName: true,
+      showTag: true,
+      showStashCount: true,
+      showUpstream: true,
+      showTimeSinceCommit: true,
+    }, ctx, {
+      branch: 'cached-main', sha: 'abc123', dirty: true, changedFiles: 2, repoName: 'repo', tag: 'v1',
+      stashCount: 3, timeSinceCommit: '4m', upstream: { name: 'origin/main', ahead: 1, behind: 2 }, refreshedAt: 1,
+    });
+    expect(git.text).toBe('repo footer-main sha: abc123 2 tag: v1 4m stash 3 origin/main ahead1 behind2');
+
+    const statuses = renderSegments({ segments: { status: { enabled: true } } }, {
+      ctx: ctx.ctx,
+      footerData: ctx.footerData,
+      symbols: getSymbols('text'),
+    });
+    expect(statuses.map((status) => status.text)).toEqual(['ready', 'bad line']);
+    expect(statuses.map((status) => status.colorKey)).toEqual(['extensionStatus1', 'extensionStatus2']);
+  });
+});
+
+function segment(name: SegmentName, text: string, align: 'left' | 'right' = 'left'): RenderedSegment {
+  return { name, colorKey: name, text, align };
+}
+
+function testConfig(overrides: Partial<PowerlineConfig['display']>): PowerlineConfig {
+  const config = configFromFlags({ getFlag: () => undefined });
+  return { ...config, display: { ...config.display, ...overrides } };
+}
+
+function renderSingle(
+  name: SegmentName,
+  config: Record<string, unknown>,
+  value: ReturnType<typeof context>,
+  gitDetails?: Parameters<typeof renderSegments>[1]['gitDetails'],
+): RenderedSegment {
+  const rendered = renderSegments({ segments: { [name]: config } }, {
+    ctx: value.ctx,
+    footerData: value.footerData,
+    ...(gitDetails === undefined ? {} : { gitDetails }),
+    symbols: getSymbols('text'),
+  });
+  expect(rendered).toHaveLength(1);
+  return rendered[0]!;
+}
+
+function context(options: {
+  cwd?: string;
+  model?: Record<string, unknown>;
+  thinkingLevel?: string;
+  providerCount?: number;
+  entries?: unknown[];
+  contextUsage?: { tokens: number | null; contextWindow: number; percent: number | null };
+  branch?: string | null;
+  statuses?: ReadonlyMap<string, string>;
+} = {}): { ctx: ExtensionContext; footerData: FooterDataLike } {
+  const ctx = {
+    cwd: options.cwd ?? '/workspace',
+    model: options.model,
+    thinkingLevel: options.thinkingLevel,
+    sessionManager: { getEntries: () => options.entries ?? [] },
+    getContextUsage: () => options.contextUsage,
+  } as unknown as ExtensionContext;
+  const footerData: FooterDataLike = {
+    getGitBranch: () => options.branch ?? null,
+    getExtensionStatuses: () => options.statuses ?? new Map(),
+    getAvailableProviderCount: () => options.providerCount ?? 1,
+    onBranchChange: () => () => {},
+  };
+  return { ctx, footerData };
+}
+
+function assistantEntry(input: number, output: number, cacheRead: number, cacheWrite: number, total: number) {
+  return {
+    type: 'message',
+    message: { role: 'assistant', usage: { input, output, cacheRead, cacheWrite, cost: { total } } },
+  };
+}

--- a/packages/ext-powerline/test/rendering.test.ts
+++ b/packages/ext-powerline/test/rendering.test.ts
@@ -65,6 +65,21 @@ describe('powerline rendering', () => {
     expect(line).toBe('left           right');
     expect(visibleWidth(line!)).toBe(20);
   });
+
+  it('pads ANSI-colored right-only groups to the terminal width', () => {
+    const config = testConfig({ style: 'minimal', padding: 0 });
+    const [line] = renderFooterLine(
+      [segment('model', '界', 'right')],
+      config,
+      getThemePalette(config),
+      'truecolor',
+      getSymbols('text'),
+      10,
+    );
+
+    expect(line).toMatch(/^ {8}\x1b\[/);
+    expect(visibleWidth(line!)).toBe(10);
+  });
 });
 
 describe('powerline segments', () => {

--- a/packages/ext-prewalk/LICENSE
+++ b/packages/ext-prewalk/LICENSE
@@ -1,6 +1,8 @@
 MIT License
 
 Copyright (c) 2026 Felan contributors
+Copyright (c) 2026 Dimitar Panayotov
+Copyright (c) 2026 Milko Slavov
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/ext-prewalk/NOTICE
+++ b/packages/ext-prewalk/NOTICE
@@ -1,0 +1,10 @@
+@felan-ai/ext-prewalk
+
+This package includes adapted portions of packages/pi-prewalk from
+mslavov/pi-extensions at commit 7e72e509fe45a5a87c4c2e176cb711de994a8c1d.
+
+Copyright (c) 2026 Dimitar Panayotov
+Copyright (c) 2026 Milko Slavov
+
+The adapted source is licensed under the MIT License. The applicable MIT
+license text and copyright notices are reproduced in LICENSE.

--- a/packages/ext-prewalk/README.md
+++ b/packages/ext-prewalk/README.md
@@ -1,3 +1,62 @@
 # @felan-ai/ext-prewalk
 
-Package foundation for the Felan prewalk extension.
+Same-session Prewalk for Felan: the current model explores and plans the work, records a validated task plan, and makes one focused mutation. Felan then switches the next model request to `openai-codex/gpt-5.6-luna`, which finishes and verifies the task with the full conversation and tool history intact.
+
+After the run settles, Prewalk restores the original planner model and thinking level by default.
+
+## Requirements
+
+- An authenticated target model
+- A Beads workspace with an active `bash` or `exec_command` tool, or an active `todo_write` tool
+- At least one active mutation tool: `edit`, `write`, or `apply_patch`
+
+When `/prewalk` is armed, it probes the current working directory with `bd status` through the active Felan `AgentRuntime`. A configured Beads workspace makes Beads the task tracker for that run; otherwise Prewalk uses `todo_write`. Prewalk refuses to arm and names the missing capability when the selected tracker or mutation tools are unavailable. Felan currently does not provide a global `todo_write` tool, so non-Beads workspaces require another extension to provide that capability.
+
+## Commands
+
+```text
+/prewalk <task>  Arm Prewalk and start the task immediately
+/prewalk         Arm Prewalk for the next ordinary prompt
+/prewalk status  Show the phase, target model, and restoration setting
+/prewalk off     Cancel Prewalk
+```
+
+`status` and `off` are handled locally and do not make a provider request. In TUI mode, an inline task is submitted as a user message. In JSON and print modes, it is submitted as a visible custom message and the command waits for the run to become idle. Turning Prewalk off after handoff restores the original planner when restoration is enabled. A manual model selection cancels Prewalk and keeps the model selected by the user.
+
+## Lifecycle
+
+1. The planner explores the relevant repository surface and determines the complete implementation scope.
+2. The planner records implementation and validation work. It uses direct `bd` CLI commands when Beads is configured, or calls `todo_write` with 5–9 items and exactly one `in_progress` item otherwise.
+3. The planner performs one focused successful `edit`, `write`, or `apply_patch` after the task-tracking gate opens.
+4. At that turn boundary, Felan switches to the configured target model.
+5. The target model completes the existing Beads graph or checklist and runs the relevant verification.
+6. Once the agent run has fully settled, Felan restores the planner model and thinking level.
+
+Tool-call order controls the handoff even when tools execute in parallel: a successful Beads task update or todo checklist followed by a mutation can qualify in the same turn, while a mutation before task tracking cannot. Failed tracking or mutation calls do not qualify. If the planner stops after prose or partial tool progress, Prewalk can queue a bounded hidden continuation, with a maximum of three per run.
+
+The handoff does not fork, summarize, or replace the session. Planning guidance and implementation guidance are transient context messages; user messages, assistant responses, task-tracking results, mutations, and verification results remain in one trajectory.
+
+## Flags
+
+Prewalk uses Pi's namespaced extension flags and does not read a configuration file.
+
+```text
+--prewalk-target-model <provider/model-id>
+--prewalk-restore-planner
+--no-prewalk-restore-planner
+```
+
+`prewalk-target-model` defaults to `openai-codex/gpt-5.6-luna`. `prewalk-restore-planner` defaults to `true`.
+
+## Failure behavior
+
+- Missing target model or authentication clears the handoff and keeps the existing trajectory.
+- A failed target-model switch clears Prewalk and reports the failure once.
+- A failed planner restoration clears Prewalk, reports the failure once, and keeps the current model.
+- A manual model change cancels Prewalk without restoring over the user's selection.
+- Session quit, reload, replacement, or fork while the target is active attempts planner restoration as a graceful shutdown backstop.
+- Reaching the automatic continuation limit lets the run settle normally.
+
+## Attribution
+
+This package adapts the MIT-licensed `packages/pi-prewalk` implementation from `mslavov/pi-extensions` at commit `7e72e509fe45a5a87c4c2e176cb711de994a8c1d`. See [NOTICE](./NOTICE) and [LICENSE](./LICENSE).

--- a/packages/ext-prewalk/package.json
+++ b/packages/ext-prewalk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felan-ai/ext-prewalk",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "description": "Same-session planner-to-implementation model handoff for Felan",
   "license": "MIT",
   "type": "module",

--- a/packages/ext-prewalk/package.json
+++ b/packages/ext-prewalk/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@felan-ai/ext-prewalk",
   "version": "0.1.0-alpha.1",
-  "description": "Prewalk extension for Felan",
+  "description": "Same-session planner-to-implementation model handoff for Felan",
   "license": "MIT",
   "type": "module",
   "repository": "github:felan-ai/felan",
   "engines": {
     "node": ">=22.19.0"
   },
-  "files": ["dist", "LICENSE", "README.md"],
+  "files": ["dist", "LICENSE", "NOTICE", "README.md"],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/ext-prewalk/src/__tests__/extension.test.ts
+++ b/packages/ext-prewalk/src/__tests__/extension.test.ts
@@ -142,9 +142,11 @@ function createHarness(
   });
   const sendMessage = vi.fn();
   const sendUserMessage = vi.fn();
-  const rawPiExec = vi.fn(async () => {
-    throw new Error('Pi host exec must not be used');
-  });
+  const facadeExec = vi.fn((
+    command: string,
+    args: string[],
+    execOptions?: Parameters<TestAgentRuntime['exec']>[2],
+  ) => runtime.exec(command, args, execOptions));
 
   const pi = {
     runtime,
@@ -160,7 +162,7 @@ function createHarness(
     }),
     getFlag: vi.fn((name: string) => flags.get(name)),
     getActiveTools: vi.fn(() => options.activeTools ?? ['read', 'bash', 'todo_write', 'edit', 'write']),
-    exec: rawPiExec,
+    exec: facadeExec,
     getThinkingLevel: vi.fn(() => thinkingLevel),
     setThinkingLevel,
     setModel,
@@ -176,7 +178,7 @@ function createHarness(
     ui,
     runtime,
     registeredFlags,
-    rawPiExec,
+    facadeExec,
     emit,
     command: commands.get('prewalk'),
     setModel,
@@ -356,13 +358,17 @@ describe('runtime routing and host/cloud parity', () => {
       await harness.command.handler('', harness.ctx);
 
       expect(harness.runtime.kind).toBe(runtimeKind);
+      expect(harness.facadeExec).toHaveBeenCalledWith(
+        'bd',
+        ['-C', '/workspace', '--readonly', '--json', 'status', '--no-activity'],
+        { timeout: 5_000 },
+      );
       expect(harness.runtime.execCalls).toEqual([{
         command: 'bd',
         args: ['-C', '/workspace', '--readonly', '--json', 'status', '--no-activity'],
         options: { timeout: 5_000 },
       }]);
       expect(harness.runtime.shellCalls).toEqual([]);
-      expect(harness.rawPiExec).not.toHaveBeenCalled();
       expect(harness.ui.notify).toHaveBeenCalledWith(expect.stringContaining('armed with Beads'), 'info');
     },
   );

--- a/packages/ext-prewalk/src/__tests__/extension.test.ts
+++ b/packages/ext-prewalk/src/__tests__/extension.test.ts
@@ -1,0 +1,685 @@
+import type {
+  ExtensionContext,
+  FelanExtensionAPI,
+  AgentRuntimeKind,
+} from '@felan-ai/agent-core';
+import { TestAgentRuntime } from '@felan-ai/agent-core/runtime-test-kit';
+import { describe, expect, it, vi } from 'vitest';
+import prewalkExtension from '../index.js';
+import {
+  CONTINUATION_MESSAGE_TYPE,
+  CONTROL_MESSAGE_PREFIX,
+  IMPLEMENTATION_MESSAGE_TYPE,
+  PLANNING_MESSAGE_TYPE,
+} from '../prompts.js';
+
+type Handler = (event: any, ctx: ExtensionContext) => any;
+
+const plannerModel = { provider: 'openai-codex', id: 'gpt-5.6-sol', name: 'Sol' } as any;
+const targetModel = { provider: 'openai-codex', id: 'gpt-5.6-luna', name: 'Luna' } as any;
+const alternateTarget = { provider: 'anthropic', id: 'claude-opus', name: 'Opus' } as any;
+const externalModel = { provider: 'anthropic', id: 'claude-sonnet', name: 'Sonnet' } as any;
+
+function validTodos() {
+  return Array.from({ length: 5 }, (_, index) => ({
+    content: `Task ${index + 1}`,
+    activeForm: `Doing task ${index + 1}`,
+    status: index === 0 ? 'in_progress' : 'pending',
+  }));
+}
+
+function assistant(
+  stopReason: 'stop' | 'toolUse' | 'error' = 'stop',
+  content: any[] = [{ type: 'text', text: 'Plan' }],
+) {
+  return {
+    role: 'assistant',
+    content,
+    api: 'openai-codex-responses',
+    provider: 'openai-codex',
+    model: 'gpt-5.6-sol',
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason,
+    timestamp: Date.now(),
+  };
+}
+
+function toolResult(toolCallId: string, toolName: string, isError = false, details?: unknown) {
+  return {
+    role: 'toolResult',
+    toolCallId,
+    toolName,
+    content: [{ type: 'text', text: isError ? 'failed' : 'ok' }],
+    details,
+    isError,
+    timestamp: Date.now(),
+  };
+}
+
+function createHarness(
+  options: {
+    activeTools?: string[];
+    models?: any[];
+    authenticated?: boolean;
+    idle?: boolean;
+    beads?: boolean;
+    mode?: 'tui' | 'rpc' | 'json' | 'print';
+    flags?: Record<string, boolean | string>;
+    runtimeKind?: AgentRuntimeKind;
+    probeThrows?: boolean;
+  } = {},
+) {
+  const handlers = new Map<string, Handler[]>();
+  const commands = new Map<string, any>();
+  const flags = new Map(Object.entries(options.flags ?? {}));
+  const registeredFlags = new Map<string, any>();
+  const models = options.models ?? [plannerModel, targetModel, alternateTarget, externalModel];
+  let currentModel = plannerModel;
+  let thinkingLevel = 'max';
+  let authenticated = options.authenticated ?? true;
+  let idle = options.idle ?? true;
+
+  const runtime = new TestAgentRuntime('/workspace', {
+    ...(options.runtimeKind === undefined ? {} : { kind: options.runtimeKind }),
+    exec: () => {
+      if (options.probeThrows) throw new Error('bd unavailable');
+      return {
+        stdout: options.beads ? '{}' : '',
+        stderr: '',
+        code: options.beads ? 0 : 1,
+        killed: false,
+      };
+    },
+  });
+  const ui = {
+    notify: vi.fn(),
+    setStatus: vi.fn(),
+  };
+  const waitForIdle = vi.fn(async () => undefined);
+
+  const ctx = {
+    ui,
+    hasUI: options.mode !== 'json' && options.mode !== 'print',
+    mode: options.mode ?? 'tui',
+    cwd: '/workspace',
+    get model() {
+      return currentModel;
+    },
+    modelRegistry: {
+      find: vi.fn((provider: string, modelId: string) => (
+        models.find((model) => model.provider === provider && model.id === modelId)
+      )),
+      hasConfiguredAuth: vi.fn(() => authenticated),
+    },
+    isIdle: vi.fn(() => idle),
+    waitForIdle,
+  } as unknown as ExtensionContext;
+
+  async function emit(type: string, event: any = { type }) {
+    let result: any;
+    for (const handler of handlers.get(type) ?? []) {
+      const handlerResult = await handler(event, ctx);
+      if (handlerResult !== undefined) result = handlerResult;
+    }
+    return result;
+  }
+
+  const setModel = vi.fn(async (model: any) => {
+    const previousModel = currentModel;
+    currentModel = model;
+    await emit('model_select', { type: 'model_select', model, previousModel, source: 'set' });
+    return true;
+  });
+  const setThinkingLevel = vi.fn((level: string) => {
+    thinkingLevel = level;
+  });
+  const sendMessage = vi.fn();
+  const sendUserMessage = vi.fn();
+  const rawPiExec = vi.fn(async () => {
+    throw new Error('Pi host exec must not be used');
+  });
+
+  const pi = {
+    runtime,
+    on: vi.fn((event: string, handler: Handler) => {
+      const eventHandlers = handlers.get(event) ?? [];
+      eventHandlers.push(handler);
+      handlers.set(event, eventHandlers);
+    }),
+    registerCommand: vi.fn((name: string, command: any) => commands.set(name, command)),
+    registerFlag: vi.fn((name: string, flagOptions: any) => {
+      registeredFlags.set(name, flagOptions);
+      if (!flags.has(name) && flagOptions.default !== undefined) flags.set(name, flagOptions.default);
+    }),
+    getFlag: vi.fn((name: string) => flags.get(name)),
+    getActiveTools: vi.fn(() => options.activeTools ?? ['read', 'bash', 'todo_write', 'edit', 'write']),
+    exec: rawPiExec,
+    getThinkingLevel: vi.fn(() => thinkingLevel),
+    setThinkingLevel,
+    setModel,
+    sendMessage,
+    sendUserMessage,
+  } as unknown as FelanExtensionAPI;
+
+  prewalkExtension(pi);
+
+  return {
+    pi,
+    ctx,
+    ui,
+    runtime,
+    registeredFlags,
+    rawPiExec,
+    emit,
+    command: commands.get('prewalk'),
+    setModel,
+    setThinkingLevel,
+    sendMessage,
+    sendUserMessage,
+    waitForIdle,
+    get currentModel() {
+      return currentModel;
+    },
+    get thinkingLevel() {
+      return thinkingLevel;
+    },
+    setCurrentModel(model: any) {
+      currentModel = model;
+    },
+    setThinking(level: string) {
+      thinkingLevel = level;
+    },
+    setAuthenticated(value: boolean) {
+      authenticated = value;
+    },
+    setIdle(value: boolean) {
+      idle = value;
+    },
+  };
+}
+
+async function startPlanning(harness: ReturnType<typeof createHarness>, task = 'Implement the feature') {
+  await harness.command.handler(task, harness.ctx);
+  await harness.emit('before_agent_start', {
+    type: 'before_agent_start',
+    prompt: task,
+    systemPrompt: 'system',
+    systemPromptOptions: {},
+  });
+}
+
+async function qualifyHandoff(harness: ReturnType<typeof createHarness>) {
+  await startPlanning(harness);
+  await harness.emit('turn_start', { type: 'turn_start', turnIndex: 0, timestamp: Date.now() });
+  await harness.emit('tool_call', {
+    type: 'tool_call',
+    toolCallId: 'todo',
+    toolName: 'todo_write',
+    input: { todos: validTodos() },
+  });
+  await harness.emit('tool_call', {
+    type: 'tool_call',
+    toolCallId: 'mutation',
+    toolName: 'edit',
+    input: { path: 'src/index.ts', oldText: 'a', newText: 'b' },
+  });
+  await harness.emit('turn_end', {
+    type: 'turn_end',
+    turnIndex: 0,
+    message: assistant('toolUse', [
+      { type: 'text', text: 'Plan' },
+      { type: 'toolCall', id: 'todo', name: 'todo_write', arguments: {} },
+      { type: 'toolCall', id: 'mutation', name: 'edit', arguments: {} },
+    ]),
+    toolResults: [
+      toolResult('mutation', 'edit'),
+      toolResult('todo', 'todo_write', false, { newTodos: validTodos() }),
+    ],
+  });
+}
+
+async function contextMessages(harness: ReturnType<typeof createHarness>, messages: any[]) {
+  const result = await harness.emit('context', { type: 'context', messages });
+  return result.messages as any[];
+}
+
+describe('flags and commands', () => {
+  it('registers namespaced Pi flags with defaults', () => {
+    const harness = createHarness();
+
+    expect(harness.registeredFlags.get('prewalk-target-model')).toMatchObject({
+      type: 'string',
+      default: 'openai-codex/gpt-5.6-luna',
+    });
+    expect(harness.registeredFlags.get('prewalk-restore-planner')).toMatchObject({
+      type: 'boolean',
+      default: true,
+    });
+  });
+
+  it('arms and sends an inline TUI task without changing sessions', async () => {
+    const harness = createHarness();
+
+    await harness.command.handler('Implement the parser', harness.ctx);
+
+    expect(harness.sendUserMessage).toHaveBeenCalledWith('Implement the parser');
+    expect(harness.setModel).not.toHaveBeenCalled();
+    expect(harness.ui.setStatus).toHaveBeenLastCalledWith(
+      'prewalk',
+      'Prewalk armed → openai-codex/gpt-5.6-luna',
+    );
+  });
+
+  it.each(['json', 'print'] as const)('keeps %s mode alive for an inline task', async (mode) => {
+    const harness = createHarness({ mode });
+
+    await harness.command.handler('Implement the parser', harness.ctx);
+
+    expect(harness.sendUserMessage).not.toHaveBeenCalled();
+    expect(harness.sendMessage).toHaveBeenCalledWith(
+      {
+        customType: 'pi-prewalk-task',
+        content: 'Implement the parser',
+        display: true,
+      },
+      { triggerTurn: true },
+    );
+    expect(harness.waitForIdle).toHaveBeenCalledOnce();
+    expect((await contextMessages(harness, [])).at(-1)?.customType).toBe(PLANNING_MESSAGE_TYPE);
+  });
+
+  it('arms the next prompt when no task is supplied', async () => {
+    const harness = createHarness();
+
+    await harness.command.handler('', harness.ctx);
+    expect(harness.sendUserMessage).not.toHaveBeenCalled();
+
+    await harness.emit('before_agent_start', {
+      type: 'before_agent_start',
+      prompt: 'Next prompt',
+      systemPrompt: 'system',
+      systemPromptOptions: {},
+    });
+    expect((await contextMessages(harness, [])).at(-1)?.customType).toBe(PLANNING_MESSAGE_TYPE);
+  });
+
+  it('handles exact status and off commands without starting inference', async () => {
+    const harness = createHarness();
+
+    await harness.command.handler('status', harness.ctx);
+    await harness.command.handler('off', harness.ctx);
+
+    expect(harness.sendUserMessage).not.toHaveBeenCalled();
+    expect(harness.sendMessage).not.toHaveBeenCalled();
+    expect(harness.setModel).not.toHaveBeenCalled();
+    expect(harness.ui.notify).toHaveBeenCalledWith(
+      'Prewalk: idle | target openai-codex/gpt-5.6-luna | restore planner on',
+      'info',
+    );
+  });
+
+  it('uses flag overrides and warns once for malformed flag values', async () => {
+    const overridden = createHarness({
+      flags: {
+        'prewalk-target-model': 'anthropic/claude-opus',
+        'prewalk-restore-planner': false,
+      },
+    });
+    await overridden.command.handler('status', overridden.ctx);
+    expect(overridden.ui.notify).toHaveBeenCalledWith(
+      'Prewalk: idle | target anthropic/claude-opus | restore planner off',
+      'info',
+    );
+
+    const malformed = createHarness({ flags: { 'prewalk-target-model': 'invalid' } });
+    await malformed.emit('session_start', { type: 'session_start', reason: 'startup' });
+    await malformed.emit('session_start', { type: 'session_start', reason: 'reload' });
+    const warnings = malformed.ui.notify.mock.calls.filter(([, type]) => type === 'warning');
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]![0]).toContain('Using defaults');
+  });
+});
+
+describe('runtime routing and host/cloud parity', () => {
+  it.each(['host', 'docker', 'daytona'] as const)(
+    'probes Beads through %s AgentRuntime exec with literal argv and timeout',
+    async (runtimeKind) => {
+      const harness = createHarness({ beads: true, runtimeKind });
+
+      await harness.command.handler('', harness.ctx);
+
+      expect(harness.runtime.kind).toBe(runtimeKind);
+      expect(harness.runtime.execCalls).toEqual([{
+        command: 'bd',
+        args: ['-C', '/workspace', '--readonly', '--json', 'status', '--no-activity'],
+        options: { timeout: 5_000 },
+      }]);
+      expect(harness.runtime.shellCalls).toEqual([]);
+      expect(harness.rawPiExec).not.toHaveBeenCalled();
+      expect(harness.ui.notify).toHaveBeenCalledWith(expect.stringContaining('armed with Beads'), 'info');
+    },
+  );
+
+  it('treats runtime probe failures as no Beads workspace', async () => {
+    const harness = createHarness({ probeThrows: true, activeTools: ['read', 'edit', 'write'] });
+
+    await harness.command.handler('Task', harness.ctx);
+
+    expect(harness.sendUserMessage).not.toHaveBeenCalled();
+    expect(harness.ui.notify).toHaveBeenCalledWith(
+      'Prewalk requires the active todo_write tool.',
+      'error',
+    );
+  });
+});
+
+describe('planning gate and context', () => {
+  it('retains explicit capability refusal when Felan has no todo_write', async () => {
+    const harness = createHarness({ activeTools: ['read', 'bash', 'edit', 'write'] });
+
+    await harness.command.handler('Task', harness.ctx);
+
+    expect(harness.sendUserMessage).not.toHaveBeenCalled();
+    expect(harness.ui.notify).toHaveBeenCalledWith(
+      'Prewalk requires the active todo_write tool.',
+      'error',
+    );
+  });
+
+  it('refuses to arm while the agent is busy', async () => {
+    const harness = createHarness({ idle: false });
+    await harness.command.handler('Task', harness.ctx);
+    expect(harness.sendUserMessage).not.toHaveBeenCalled();
+    expect(harness.ui.notify).toHaveBeenCalledWith(
+      'Prewalk can only be armed while the agent is idle.',
+      'warning',
+    );
+  });
+
+  it('detects a Beads workspace and hands off after Beads tracking', async () => {
+    const harness = createHarness({ beads: true });
+    await startPlanning(harness);
+
+    const planning = await contextMessages(harness, []);
+    expect(planning.at(-1)?.content).toContain('Use the beads skill and direct bd CLI commands');
+    expect(planning.at(-1)?.content).toContain('instead of todo_write');
+
+    await harness.emit('turn_start', { type: 'turn_start', turnIndex: 0, timestamp: Date.now() });
+    await harness.emit('tool_call', {
+      type: 'tool_call',
+      toolCallId: 'beads',
+      toolName: 'bash',
+      input: { command: "bd create --title 'Implement feature' --type task" },
+    });
+    await harness.emit('tool_call', {
+      type: 'tool_call',
+      toolCallId: 'mutation',
+      toolName: 'edit',
+      input: { path: 'src/index.ts', oldText: 'a', newText: 'b' },
+    });
+    await harness.emit('turn_end', {
+      type: 'turn_end',
+      turnIndex: 0,
+      message: assistant('toolUse'),
+      toolResults: [toolResult('beads', 'bash'), toolResult('mutation', 'edit')],
+    });
+
+    expect(harness.setModel).toHaveBeenCalledWith(targetModel);
+    const implementing = await contextMessages(harness, []);
+    expect(implementing.at(-1)?.content).toContain('close each completed Bead');
+    expect(implementing.at(-1)?.content).toContain('instead of todo_write');
+  });
+
+  it('blocks invalid planning checklists before todo_write executes', async () => {
+    const harness = createHarness();
+    await startPlanning(harness);
+    await harness.emit('turn_start', { type: 'turn_start', turnIndex: 0, timestamp: Date.now() });
+
+    const blocked = await harness.emit('tool_call', {
+      type: 'tool_call',
+      toolCallId: 'todo',
+      toolName: 'todo_write',
+      input: { todos: validTodos().slice(0, 4) },
+    });
+
+    expect(blocked).toEqual({
+      block: true,
+      reason: 'Prewalk requires 5-9 todo items before the first mutation.',
+    });
+  });
+
+  it('preserves unrelated history while replacing only its own phase message', async () => {
+    const harness = createHarness();
+    await startPlanning(harness);
+    const original = [
+      { role: 'user', content: 'Task', timestamp: 1 },
+      toolResult('old-todo', 'todo_write', false, { newTodos: validTodos() }),
+      { role: 'custom', customType: 'other-extension', content: 'keep', display: false, timestamp: 2 },
+      { role: 'custom', customType: `${CONTROL_MESSAGE_PREFIX}stale`, content: 'remove', display: false, timestamp: 3 },
+    ];
+
+    const planning = await contextMessages(harness, original);
+    expect(planning).toHaveLength(4);
+    expect(planning[0]).toEqual(original[0]);
+    expect(planning[0]).not.toBe(original[0]);
+    expect(planning[1]).toEqual(original[1]);
+    expect(planning[2]).toEqual(original[2]);
+    expect(planning.at(-1)?.customType).toBe(PLANNING_MESSAGE_TYPE);
+
+    await qualifyHandoff(harness);
+    const implementing = await contextMessages(harness, planning);
+    const ownMessages = implementing.filter(
+      (message) => message.role === 'custom' && message.customType.startsWith(CONTROL_MESSAGE_PREFIX),
+    );
+    expect(ownMessages).toHaveLength(1);
+    expect(ownMessages[0].customType).toBe(IMPLEMENTATION_MESSAGE_TYPE);
+    expect(implementing).toEqual(expect.arrayContaining([
+      expect.objectContaining({ role: 'toolResult', toolName: 'todo_write' }),
+    ]));
+  });
+
+  it('queues a hidden continuation once per no-progress stretch', async () => {
+    const harness = createHarness();
+    await startPlanning(harness);
+
+    await harness.emit('turn_start', { type: 'turn_start', turnIndex: 0, timestamp: Date.now() });
+    await harness.emit('turn_end', {
+      type: 'turn_end',
+      turnIndex: 0,
+      message: assistant(),
+      toolResults: [],
+    });
+    expect(harness.sendMessage).toHaveBeenCalledWith(
+      { customType: CONTINUATION_MESSAGE_TYPE, content: '', display: false },
+      { deliverAs: 'followUp' },
+    );
+
+    await harness.emit('turn_start', { type: 'turn_start', turnIndex: 1, timestamp: Date.now() });
+    await harness.emit('turn_end', {
+      type: 'turn_end',
+      turnIndex: 1,
+      message: assistant(),
+      toolResults: [],
+    });
+    expect(harness.sendMessage).toHaveBeenCalledTimes(1);
+
+    await harness.emit('turn_start', { type: 'turn_start', turnIndex: 2, timestamp: Date.now() });
+    await harness.emit('tool_call', {
+      type: 'tool_call', toolCallId: 'read', toolName: 'read', input: { path: 'x' },
+    });
+    await harness.emit('turn_end', {
+      type: 'turn_end',
+      turnIndex: 2,
+      message: assistant('toolUse'),
+      toolResults: [toolResult('read', 'read')],
+    });
+    await harness.emit('turn_start', { type: 'turn_start', turnIndex: 3, timestamp: Date.now() });
+    await harness.emit('turn_end', {
+      type: 'turn_end',
+      turnIndex: 3,
+      message: assistant(),
+      toolResults: [],
+    });
+    expect(harness.sendMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not continue provider errors', async () => {
+    const harness = createHarness();
+    await startPlanning(harness);
+    await harness.emit('turn_start', { type: 'turn_start', turnIndex: 0, timestamp: Date.now() });
+    await harness.emit('turn_end', {
+      type: 'turn_end', turnIndex: 0, message: assistant('error', []), toolResults: [],
+    });
+
+    expect(harness.sendMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe('model handoff and restoration', () => {
+  it('switches once at turn_end and restores model before thinking at agent_settled', async () => {
+    const harness = createHarness();
+
+    await qualifyHandoff(harness);
+    expect(harness.setModel).toHaveBeenCalledTimes(1);
+    expect(harness.setModel).toHaveBeenNthCalledWith(1, targetModel);
+    expect(harness.currentModel).toBe(targetModel);
+    expect((await contextMessages(harness, [])).at(-1)?.customType).toBe(IMPLEMENTATION_MESSAGE_TYPE);
+
+    harness.setThinking('low');
+    await harness.emit('agent_settled', { type: 'agent_settled' });
+
+    expect(harness.setModel).toHaveBeenNthCalledWith(2, plannerModel);
+    expect(harness.setThinkingLevel).toHaveBeenCalledWith('max');
+    expect(harness.setModel.mock.invocationCallOrder[1]).toBeLessThan(
+      harness.setThinkingLevel.mock.invocationCallOrder[0]!,
+    );
+    expect(harness.currentModel).toBe(plannerModel);
+    expect(harness.thinkingLevel).toBe('max');
+    expect(await contextMessages(harness, [])).toEqual([]);
+  });
+
+  it('restores the planner when turned off after handoff', async () => {
+    const harness = createHarness();
+    await qualifyHandoff(harness);
+
+    await harness.command.handler('off', harness.ctx);
+
+    expect(harness.setModel).toHaveBeenNthCalledWith(2, plannerModel);
+    expect(harness.currentModel).toBe(plannerModel);
+  });
+
+  it('uses session_shutdown as a restoration backstop', async () => {
+    const harness = createHarness();
+    await qualifyHandoff(harness);
+    harness.setThinking('low');
+
+    await harness.emit('session_shutdown', { type: 'session_shutdown', reason: 'reload' });
+
+    expect(harness.currentModel).toBe(plannerModel);
+    expect(harness.thinkingLevel).toBe('max');
+  });
+
+  it('keeps the target when restoration is disabled', async () => {
+    const harness = createHarness({ flags: { 'prewalk-restore-planner': false } });
+    await qualifyHandoff(harness);
+
+    await harness.emit('agent_settled', { type: 'agent_settled' });
+
+    expect(harness.setModel).toHaveBeenCalledTimes(1);
+    expect(harness.currentModel).toBe(targetModel);
+    expect(harness.setThinkingLevel).not.toHaveBeenCalled();
+  });
+
+  it('clears after one failed restoration without retrying', async () => {
+    const harness = createHarness();
+    await qualifyHandoff(harness);
+    harness.setModel.mockResolvedValueOnce(false);
+
+    await harness.emit('agent_settled', { type: 'agent_settled' });
+    await harness.emit('agent_settled', { type: 'agent_settled' });
+
+    expect(harness.setModel).toHaveBeenCalledTimes(2);
+    expect(harness.ui.notify).toHaveBeenCalledWith(expect.stringContaining('could not restore'), 'error');
+  });
+});
+
+describe('model failures and manual control', () => {
+  it('cancels when the target model is unavailable', async () => {
+    const harness = createHarness({ models: [plannerModel] });
+    await qualifyHandoff(harness);
+
+    expect(harness.setModel).not.toHaveBeenCalled();
+    expect(harness.ui.notify).toHaveBeenCalledWith(
+      'Prewalk target model is unavailable: openai-codex/gpt-5.6-luna.',
+      'error',
+    );
+    expect(await contextMessages(harness, [])).toEqual([]);
+  });
+
+  it('cancels when target authentication is unavailable', async () => {
+    const harness = createHarness({ authenticated: false });
+    await qualifyHandoff(harness);
+
+    expect(harness.setModel).not.toHaveBeenCalled();
+    expect(harness.ui.notify).toHaveBeenCalledWith(expect.stringContaining('not authenticated'), 'error');
+  });
+
+  it.each([
+    ['returns false', (harness: ReturnType<typeof createHarness>) => harness.setModel.mockResolvedValueOnce(false)],
+    ['throws', (harness: ReturnType<typeof createHarness>) => (
+      harness.setModel.mockRejectedValueOnce(new Error('switch failed'))
+    )],
+  ])('cancels when setModel %s', async (_label, arrange) => {
+    const harness = createHarness();
+    arrange(harness);
+
+    await qualifyHandoff(harness);
+
+    expect(await contextMessages(harness, [])).toEqual([]);
+    expect(harness.ui.notify).toHaveBeenCalledWith(expect.stringContaining('could not switch'), 'error');
+  });
+
+  it('cancels planning on an external model selection and retains that model', async () => {
+    const harness = createHarness();
+    await startPlanning(harness);
+    harness.setCurrentModel(externalModel);
+
+    await harness.emit('model_select', {
+      type: 'model_select', model: externalModel, previousModel: plannerModel, source: 'cycle',
+    });
+    await harness.emit('agent_settled', { type: 'agent_settled' });
+
+    expect(harness.currentModel).toBe(externalModel);
+    expect(harness.setModel).not.toHaveBeenCalled();
+    expect(await contextMessages(harness, [])).toEqual([]);
+  });
+
+  it('does not restore over a manual model selection after handoff', async () => {
+    const harness = createHarness();
+    await qualifyHandoff(harness);
+    harness.setCurrentModel(externalModel);
+    await harness.emit('model_select', {
+      type: 'model_select', model: externalModel, previousModel: targetModel, source: 'cycle',
+    });
+
+    await harness.emit('agent_settled', { type: 'agent_settled' });
+
+    expect(harness.setModel).toHaveBeenCalledTimes(1);
+    expect(harness.currentModel).toBe(externalModel);
+  });
+
+  it('uses the target model selected by the namespaced flag', async () => {
+    const harness = createHarness({ flags: { 'prewalk-target-model': 'anthropic/claude-opus' } });
+
+    await qualifyHandoff(harness);
+
+    expect(harness.setModel).toHaveBeenCalledWith(alternateTarget);
+  });
+});

--- a/packages/ext-prewalk/src/__tests__/state.test.ts
+++ b/packages/ext-prewalk/src/__tests__/state.test.ts
@@ -106,9 +106,16 @@ describe('todo_write validation', () => {
 });
 
 describe('turn reduction', () => {
-  it('accepts a successful Beads update as the tracking gate', () => {
+  it.each([
+    "bd create --title 'Implement parser' --type task",
+    'bd update FEL-9 --status in_progress',
+    'cd repo && bd update FEL-9 --status in_progress',
+    'cd repo; bd close FEL-9',
+    'cd repo\nbd reopen FEL-9',
+    'MODE=local bd comment FEL-9 "Implementation started"',
+  ])('accepts a successful direct or chained Beads mutation: %s', (command) => {
     let state = createRunState();
-    state = beadsCall(state, 'beads', "bd create --title 'Implement parser' --type task");
+    state = beadsCall(state, 'beads', command);
     state = call(state, 'mutation', 'edit');
 
     expect(reduceTurn(state, [ok('beads'), ok('mutation')]).shouldHandoff).toBe(true);
@@ -133,6 +140,24 @@ describe('turn reduction', () => {
     state = call(state, 'mutation', 'edit');
 
     expect(reduceTurn(state, [ok('status'), ok('git'), ok('mutation')]).shouldHandoff).toBe(false);
+  });
+
+  it.each([
+    'echo bd update FEL-9 --status in_progress',
+    'echo "bd update FEL-9 --status in_progress"',
+    "printf '%s\\n' 'bd update FEL-9 --status in_progress'",
+    "git commit -m 'bd update FEL-9'",
+    "message='bd update FEL-9' && echo \"$message\"",
+    ": 'bd update FEL-9 --status in_progress'",
+    'bd status --format update',
+    '# bd update FEL-9 --status in_progress',
+    'echo done # bd update FEL-9 --status in_progress',
+  ])('does not treat Beads command text as tracking: %s', (command) => {
+    let state = createRunState();
+    state = beadsCall(state, 'beads-text', command);
+    state = call(state, 'mutation', 'edit');
+
+    expect(reduceTurn(state, [ok('beads-text'), ok('mutation')]).shouldHandoff).toBe(false);
   });
 
   it('hands off after an open gate and a successful mutation', () => {

--- a/packages/ext-prewalk/src/__tests__/state.test.ts
+++ b/packages/ext-prewalk/src/__tests__/state.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, it } from 'vitest';
+import {
+  BEADS_PLANNING_INSTRUCTION,
+  BEADS_VERIFICATION_INSTRUCTION,
+  MAX_AUTOMATIC_CONTINUATIONS,
+  PLANNING_INSTRUCTION,
+  VERIFICATION_INSTRUCTION,
+} from '../prompts.js';
+import {
+  beginTurn,
+  createRunState,
+  recordToolCall,
+  reduceTurn,
+  validateArmingTools,
+  validateTodoWriteInput,
+  type PrewalkRunState,
+  type ToolResultSummary,
+} from '../state.js';
+
+function todos(count: number, inProgressIndexes: number[] = [0]) {
+  return Array.from({ length: count }, (_, index) => ({
+    content: `Task ${index + 1}`,
+    activeForm: `Doing task ${index + 1}`,
+    status: inProgressIndexes.includes(index) ? 'in_progress' : 'pending',
+  }));
+}
+
+function call(state: PrewalkRunState, toolCallId: string, toolName: string): PrewalkRunState {
+  return recordToolCall(state, { toolCallId, toolName });
+}
+
+function beadsCall(state: PrewalkRunState, toolCallId: string, command: string): PrewalkRunState {
+  return recordToolCall(state, { toolCallId, toolName: 'bash', input: { command } }, true);
+}
+
+function ok(toolCallId: string): ToolResultSummary {
+  return { toolCallId, isError: false };
+}
+
+function error(toolCallId: string): ToolResultSummary {
+  return { toolCallId, isError: true };
+}
+
+describe('arming validation', () => {
+  it.each(['edit', 'write', 'apply_patch'])('accepts todo_write with %s', (mutationTool) => {
+    expect(validateArmingTools(['read', 'todo_write', mutationTool])).toEqual({ ok: true });
+  });
+
+  it('requires a shell tool instead of todo_write for Beads tracking', () => {
+    expect(validateArmingTools(['bash', 'edit'], true)).toEqual({ ok: true });
+    expect(validateArmingTools(['todo_write', 'edit'], true)).toEqual({
+      ok: false,
+      reason: 'Prewalk requires an active shell tool (bash or exec_command).',
+    });
+  });
+
+  it('reports each missing capability', () => {
+    expect(validateArmingTools(['edit'])).toEqual({
+      ok: false,
+      reason: 'Prewalk requires the active todo_write tool.',
+    });
+    expect(validateArmingTools(['todo_write'])).toEqual({
+      ok: false,
+      reason: 'Prewalk requires an active mutation tool (edit, write, or apply_patch).',
+    });
+    expect(validateArmingTools(['read'])).toEqual({
+      ok: false,
+      reason: 'Prewalk requires the active todo_write tool and an active mutation tool (edit, write, or apply_patch).',
+    });
+  });
+});
+
+describe('todo_write validation', () => {
+  it.each([5, 9])('accepts %s items and exactly one in_progress item', (count) => {
+    expect(validateTodoWriteInput({ todos: todos(count) })).toEqual({ ok: true });
+  });
+
+  it.each([4, 10])('rejects the adjacent %s-item boundary', (count) => {
+    expect(validateTodoWriteInput({ todos: todos(count) })).toEqual({
+      ok: false,
+      reason: 'Prewalk requires 5-9 todo items before the first mutation.',
+    });
+  });
+
+  it('requires exactly one in_progress item', () => {
+    expect(validateTodoWriteInput({ todos: todos(5, []) })).toEqual({
+      ok: false,
+      reason: 'Prewalk requires exactly one in_progress todo item.',
+    });
+    expect(validateTodoWriteInput({ todos: todos(5, [0, 1]) })).toEqual({
+      ok: false,
+      reason: 'Prewalk requires exactly one in_progress todo item.',
+    });
+  });
+
+  it('rejects malformed input with actionable reasons', () => {
+    expect(validateTodoWriteInput({})).toEqual({
+      ok: false,
+      reason: 'Prewalk requires todo_write input with a todos array.',
+    });
+    expect(validateTodoWriteInput({ todos: [...todos(4), { status: 'unknown' }] })).toEqual({
+      ok: false,
+      reason: 'Every Prewalk todo must have a valid pending, in_progress, or completed status.',
+    });
+  });
+});
+
+describe('turn reduction', () => {
+  it('accepts a successful Beads update as the tracking gate', () => {
+    let state = createRunState();
+    state = beadsCall(state, 'beads', "bd create --title 'Implement parser' --type task");
+    state = call(state, 'mutation', 'edit');
+
+    expect(reduceTurn(state, [ok('beads'), ok('mutation')]).shouldHandoff).toBe(true);
+  });
+
+  it('accepts exec_command Beads updates using cmd input', () => {
+    let state = createRunState();
+    state = recordToolCall(
+      state,
+      { toolCallId: 'beads', toolName: 'exec_command', input: { cmd: 'bd update FEL-9 --status in_progress' } },
+      true,
+    );
+    state = call(state, 'mutation', 'write');
+
+    expect(reduceTurn(state, [ok('beads'), ok('mutation')]).shouldHandoff).toBe(true);
+  });
+
+  it('ignores read-only and unrelated shell commands for the Beads gate', () => {
+    let state = createRunState();
+    state = beadsCall(state, 'status', 'bd status');
+    state = beadsCall(state, 'git', 'git status');
+    state = call(state, 'mutation', 'edit');
+
+    expect(reduceTurn(state, [ok('status'), ok('git'), ok('mutation')]).shouldHandoff).toBe(false);
+  });
+
+  it('hands off after an open gate and a successful mutation', () => {
+    let state = { ...createRunState(), trackingGateOpen: true };
+    state = call(state, 'mutation', 'edit');
+
+    expect(reduceTurn(state, [ok('mutation')]).shouldHandoff).toBe(true);
+  });
+
+  it('hands off when successful tracking precedes a successful mutation in one turn', () => {
+    let state = createRunState();
+    state = call(state, 'todo', 'todo_write');
+    state = call(state, 'read', 'read');
+    state = call(state, 'mutation', 'write');
+
+    const decision = reduceTurn(state, [ok('mutation'), ok('todo'), ok('read')]);
+
+    expect(decision.shouldHandoff).toBe(true);
+    expect(decision.state.trackingGateOpen).toBe(true);
+  });
+
+  it('uses call order rather than parallel result order', () => {
+    let state = createRunState();
+    state = call(state, 'todo', 'todo_write');
+    state = call(state, 'mutation', 'apply_patch');
+
+    expect(reduceTurn(state, [ok('mutation'), ok('todo')]).shouldHandoff).toBe(true);
+    expect(reduceTurn(state, [ok('todo'), ok('mutation')]).shouldHandoff).toBe(true);
+  });
+
+  it('does not retain a mutation that precedes successful tracking', () => {
+    let state = createRunState();
+    state = call(state, 'early-mutation', 'edit');
+    state = call(state, 'todo', 'todo_write');
+
+    const firstTurn = reduceTurn(state, [ok('todo'), ok('early-mutation')]);
+    expect(firstTurn.shouldHandoff).toBe(false);
+    expect(firstTurn.state.trackingGateOpen).toBe(true);
+
+    state = call(beginTurn(firstTurn.state), 'later-mutation', 'edit');
+    expect(reduceTurn(state, [ok('later-mutation')]).shouldHandoff).toBe(true);
+  });
+
+  it('requires successful tracking and mutation results', () => {
+    let state = createRunState();
+    state = call(state, 'todo', 'todo_write');
+    state = call(state, 'mutation', 'write');
+
+    const failedTodo = reduceTurn(state, [error('todo'), ok('mutation')]);
+    expect(failedTodo.shouldHandoff).toBe(false);
+    expect(failedTodo.state.trackingGateOpen).toBe(false);
+
+    const failedMutation = reduceTurn(state, [ok('todo'), error('mutation')]);
+    expect(failedMutation.shouldHandoff).toBe(false);
+    expect(failedMutation.state.trackingGateOpen).toBe(true);
+
+    state = call(beginTurn(failedMutation.state), 'retry', 'write');
+    expect(reduceTurn(state, [ok('retry')]).shouldHandoff).toBe(true);
+  });
+
+  it('ignores unrelated successful results for the handoff gate', () => {
+    let state = createRunState();
+    state = call(state, 'read', 'read');
+
+    expect(reduceTurn(state, [ok('read')]).shouldHandoff).toBe(false);
+  });
+});
+
+describe('bounded planning continuations', () => {
+  it('queues only once during a no-progress stretch', () => {
+    const first = reduceTurn(createRunState(), []);
+    const second = reduceTurn(beginTurn(first.state), []);
+
+    expect(first.shouldContinue).toBe(true);
+    expect(second.shouldContinue).toBe(false);
+    expect(second.state.continuationCount).toBe(1);
+  });
+
+  it('rearms after any successful tool result', () => {
+    const first = reduceTurn(createRunState(), []);
+    const progress = reduceTurn(beginTurn(first.state), [ok('read')]);
+    const afterProgress = reduceTurn(beginTurn(progress.state), []);
+
+    expect(progress.shouldContinue).toBe(false);
+    expect(afterProgress.shouldContinue).toBe(true);
+    expect(afterProgress.state.continuationCount).toBe(2);
+  });
+
+  it('does not rearm after a failed tool result', () => {
+    const first = reduceTurn(createRunState(), []);
+    const failure = reduceTurn(beginTurn(first.state), [error('read')]);
+    const afterFailure = reduceTurn(beginTurn(failure.state), []);
+
+    expect(afterFailure.shouldContinue).toBe(false);
+  });
+
+  it('never exceeds the continuation cap', () => {
+    let state = createRunState();
+
+    for (let index = 0; index < MAX_AUTOMATIC_CONTINUATIONS; index += 1) {
+      const continuation = reduceTurn(beginTurn(state), []);
+      expect(continuation.shouldContinue).toBe(true);
+      state = reduceTurn(beginTurn(continuation.state), [ok(`progress-${index}`)]).state;
+    }
+
+    const exhausted = reduceTurn(beginTurn(state), []);
+    expect(exhausted.shouldContinue).toBe(false);
+    expect(exhausted.state.continuationCount).toBe(MAX_AUTOMATIC_CONTINUATIONS);
+  });
+
+  it('does not queue a continuation when the turn qualifies for handoff', () => {
+    let state = { ...createRunState(), trackingGateOpen: true };
+    state = call(state, 'mutation', 'edit');
+
+    const decision = reduceTurn(state, [ok('mutation')]);
+    expect(decision.shouldHandoff).toBe(true);
+    expect(decision.shouldContinue).toBe(false);
+  });
+
+  it('does not consume the continuation budget for an ineligible completion', () => {
+    const decision = reduceTurn(createRunState(), [], { allowContinuation: false });
+
+    expect(decision.shouldContinue).toBe(false);
+    expect(decision.state.continuationCount).toBe(0);
+    expect(decision.state.continuationArmed).toBe(true);
+  });
+});
+
+describe('phase prompts', () => {
+  it('requires repository exploration, detailed tasks, and immediate implementation', () => {
+    expect(PLANNING_INSTRUCTION).toContain('Explore the repository thoroughly');
+    expect(PLANNING_INSTRUCTION).toContain('affected files and symbols');
+    expect(PLANNING_INSTRUCTION).toContain('5-9 detailed implementation tasks');
+    expect(PLANNING_INSTRUCTION).toContain('Start implementing immediately');
+  });
+
+  it('requires focused completion and full verification', () => {
+    expect(VERIFICATION_INSTRUCTION).toContain('existing todo_write checklist in task order');
+    expect(VERIFICATION_INSTRUCTION).toContain('limited to the requested scope');
+    expect(VERIFICATION_INSTRUCTION).toContain('full relevant test module or suite');
+  });
+
+  it('creates and executes a dependency-aware Beads task graph', () => {
+    expect(BEADS_PLANNING_INSTRUCTION).toContain('direct bd CLI commands');
+    expect(BEADS_PLANNING_INSTRUCTION).toContain('Create detailed Beads tasks');
+    expect(BEADS_PLANNING_INSTRUCTION).toContain('add dependencies');
+    expect(BEADS_PLANNING_INSTRUCTION).toContain('while honoring their dependencies');
+    expect(BEADS_VERIFICATION_INSTRUCTION).toContain('Honor task dependencies');
+    expect(BEADS_VERIFICATION_INSTRUCTION).toContain('close each completed Bead');
+  });
+
+  it('does not expose orchestration details', () => {
+    const instructions = [
+      PLANNING_INSTRUCTION,
+      VERIFICATION_INSTRUCTION,
+      BEADS_PLANNING_INSTRUCTION,
+      BEADS_VERIFICATION_INSTRUCTION,
+    ].join('\n');
+
+    expect(instructions).not.toMatch(/\b(?:handoff|model|trajectory)\b|planning phase|next request|first mutation/i);
+  });
+});

--- a/packages/ext-prewalk/src/index.ts
+++ b/packages/ext-prewalk/src/index.ts
@@ -1,3 +1,501 @@
-const prewalkExtension = (): void => {};
+import type {
+  ExtensionContext,
+  FelanExtension,
+  FelanExtensionAPI,
+} from '@felan-ai/agent-core';
+import {
+  BEADS_PLANNING_INSTRUCTION,
+  BEADS_VERIFICATION_INSTRUCTION,
+  CONTINUATION_MESSAGE_TYPE,
+  CONTROL_MESSAGE_PREFIX,
+  IMPLEMENTATION_MESSAGE_TYPE,
+  PLANNING_INSTRUCTION,
+  PLANNING_MESSAGE_TYPE,
+  VERIFICATION_INSTRUCTION,
+} from './prompts.js';
+import {
+  beginTurn,
+  createRunState,
+  recordToolCall,
+  reduceTurn,
+  validateArmingTools,
+  validateTodoWriteInput,
+  type PrewalkPhase,
+  type PrewalkState,
+} from './state.js';
+
+type PlannerModel = NonNullable<ExtensionContext['model']>;
+type PlannerThinkingLevel = ReturnType<FelanExtensionAPI['getThinkingLevel']>;
+type NotificationType = 'info' | 'warning' | 'error';
+
+interface PrewalkConfig {
+  targetModel: string;
+  restorePlanner: boolean;
+}
+
+interface TargetModel {
+  provider: string;
+  modelId: string;
+  key: string;
+}
+
+interface PlannerSnapshot {
+  model: PlannerModel;
+  modelKey: string;
+  thinkingLevel: PlannerThinkingLevel;
+}
+
+const DEFAULT_CONFIG: PrewalkConfig = {
+  targetModel: 'openai-codex/gpt-5.6-luna',
+  restorePlanner: true,
+};
+const TARGET_MODEL_FLAG = 'prewalk-target-model';
+const RESTORE_PLANNER_FLAG = 'prewalk-restore-planner';
+const HEADLESS_TASK_MESSAGE_TYPE = 'pi-prewalk-task';
+
+const prewalkExtension: FelanExtension = (pi): void => {
+  pi.registerFlag(TARGET_MODEL_FLAG, {
+    description: 'Model used to implement a planned Prewalk task (provider/model-id)',
+    type: 'string',
+    default: DEFAULT_CONFIG.targetModel,
+  });
+  pi.registerFlag(RESTORE_PLANNER_FLAG, {
+    description: 'Restore the planner model and thinking level after implementation',
+    type: 'boolean',
+    default: DEFAULT_CONFIG.restorePlanner,
+  });
+
+  let loadedConfig: ReturnType<typeof loadConfig> = { config: { ...DEFAULT_CONFIG } };
+  let config = loadedConfig.config;
+  let targetModel = parseTargetModel(config.targetModel)!;
+  let configWarningShown = false;
+  let state: PrewalkState = { phase: 'idle' };
+  let plannerSnapshot: PlannerSnapshot | undefined;
+  let expectedModelKey: string | undefined;
+  let useBeads = false;
+
+  function refreshConfig(): void {
+    loadedConfig = loadConfig(pi);
+    config = loadedConfig.config;
+    targetModel = parseTargetModel(config.targetModel)!;
+  }
+
+  function notify(ctx: ExtensionContext, message: string, type: NotificationType = 'info'): void {
+    if (ctx.hasUI) {
+      ctx.ui.notify(message, type);
+    } else {
+      console.error(message);
+    }
+  }
+
+  function publishConfigWarning(ctx: ExtensionContext): void {
+    if (!loadedConfig.warning || configWarningShown) return;
+    configWarningShown = true;
+    notify(ctx, `Prewalk flag warning: ${loadedConfig.warning} Using defaults.`, 'warning');
+  }
+
+  function updateStatus(ctx: ExtensionContext): void {
+    if (state.phase === 'idle') {
+      ctx.ui.setStatus('prewalk', undefined);
+      return;
+    }
+
+    const continuationCount = state.run?.continuationCount ?? 0;
+    const continuationText = state.phase === 'planning' && continuationCount > 0
+      ? ` · ${continuationCount}/3`
+      : '';
+    ctx.ui.setStatus('prewalk', `Prewalk ${state.phase}${continuationText} → ${targetModel.key}`);
+  }
+
+  function publishStatus(ctx: ExtensionContext): void {
+    publishConfigWarning(ctx);
+    const planner = plannerSnapshot ? ` | planner ${plannerSnapshot.modelKey}` : '';
+    notify(
+      ctx,
+      `Prewalk: ${state.phase} | target ${targetModel.key} | restore planner ${config.restorePlanner ? 'on' : 'off'}${planner}`,
+    );
+  }
+
+  function clearAutomation(ctx: ExtensionContext): void {
+    state = { phase: 'idle' };
+    plannerSnapshot = undefined;
+    expectedModelKey = undefined;
+    useBeads = false;
+    updateStatus(ctx);
+  }
+
+  function failAutomation(ctx: ExtensionContext, message: string): void {
+    clearAutomation(ctx);
+    notify(ctx, message, 'error');
+  }
+
+  async function arm(ctx: ExtensionContext): Promise<boolean> {
+    publishConfigWarning(ctx);
+    if (state.phase !== 'idle') {
+      notify(ctx, `Prewalk is already ${state.phase}. Use /prewalk off before starting another run.`, 'warning');
+      return false;
+    }
+    if (!ctx.isIdle()) {
+      notify(ctx, 'Prewalk can only be armed while the agent is idle.', 'warning');
+      return false;
+    }
+
+    useBeads = await hasBeadsWorkspace(pi, ctx.cwd);
+    const validation = validateArmingTools(pi.getActiveTools(), useBeads);
+    if (!validation.ok) {
+      notify(ctx, validation.reason, 'error');
+      return false;
+    }
+
+    state = { phase: 'armed' };
+    updateStatus(ctx);
+    const tracking = useBeads ? 'Beads' : 'todo_write';
+    notify(ctx, `Prewalk armed with ${tracking}. The next task will plan, make one mutation, then hand off to ${targetModel.key}.`);
+    return true;
+  }
+
+  function beginRun(ctx: ExtensionContext): void {
+    if (state.phase !== 'armed') return;
+    if (!ctx.model) {
+      failAutomation(ctx, 'Prewalk requires a selected planner model.');
+      return;
+    }
+
+    plannerSnapshot = {
+      model: ctx.model,
+      modelKey: modelKey(ctx.model),
+      thinkingLevel: pi.getThinkingLevel(),
+    };
+    state = { phase: 'planning', run: createRunState() };
+    updateStatus(ctx);
+  }
+
+  async function switchToTarget(ctx: ExtensionContext): Promise<void> {
+    if (state.phase !== 'planning' || !state.run || !plannerSnapshot) return;
+
+    const run = state.run;
+    const snapshot = plannerSnapshot;
+    state = { phase: 'handoff', run };
+    updateStatus(ctx);
+
+    const target = ctx.modelRegistry.find(targetModel.provider, targetModel.modelId);
+    if (!target) {
+      failAutomation(ctx, `Prewalk target model is unavailable: ${targetModel.key}.`);
+      return;
+    }
+    if (!ctx.modelRegistry.hasConfiguredAuth(target)) {
+      failAutomation(ctx, `Prewalk target model is not authenticated: ${targetModel.key}.`);
+      return;
+    }
+
+    try {
+      expectedModelKey = targetModel.key;
+      const switched = await pi.setModel(target);
+      if (state.phase !== 'handoff' || plannerSnapshot !== snapshot) return;
+      if (!switched) {
+        failAutomation(ctx, `Prewalk could not switch to ${targetModel.key}.`);
+        return;
+      }
+
+      state = { phase: 'implementing', run };
+      updateStatus(ctx);
+      notify(ctx, `Prewalk handed implementation to ${targetModel.key}.`);
+    } catch (error) {
+      if (state.phase === 'handoff' && plannerSnapshot === snapshot) {
+        failAutomation(ctx, `Prewalk could not switch to ${targetModel.key}: ${errorMessage(error)}`);
+      }
+    } finally {
+      if (expectedModelKey === targetModel.key) expectedModelKey = undefined;
+    }
+  }
+
+  async function restorePlanner(ctx: ExtensionContext): Promise<boolean> {
+    const snapshot = plannerSnapshot;
+    if (!snapshot) {
+      clearAutomation(ctx);
+      return true;
+    }
+
+    state = { phase: 'restoring', run: state.run! };
+    updateStatus(ctx);
+
+    try {
+      if (modelKey(ctx.model) !== snapshot.modelKey) {
+        expectedModelKey = snapshot.modelKey;
+        const restored = await pi.setModel(snapshot.model);
+        if (state.phase !== 'restoring' || plannerSnapshot !== snapshot) return false;
+        if (!restored) throw new Error(`model ${snapshot.modelKey} is not authenticated`);
+      }
+
+      if (state.phase !== 'restoring' || plannerSnapshot !== snapshot) return false;
+      pi.setThinkingLevel(snapshot.thinkingLevel);
+      clearAutomation(ctx);
+      return true;
+    } catch (error) {
+      if (state.phase !== 'idle') {
+        clearAutomation(ctx);
+        notify(ctx, `Prewalk could not restore ${snapshot.modelKey}: ${errorMessage(error)}`, 'error');
+      }
+      return false;
+    } finally {
+      if (expectedModelKey === snapshot.modelKey) expectedModelKey = undefined;
+    }
+  }
+
+  async function turnOff(ctx: ExtensionContext): Promise<void> {
+    if (state.phase === 'idle') {
+      notify(ctx, 'Prewalk is already off.');
+      return;
+    }
+
+    const targetIsActive = state.phase === 'handoff'
+      || state.phase === 'implementing'
+      || state.phase === 'restoring';
+    if (targetIsActive && config.restorePlanner && plannerSnapshot) {
+      const restored = await restorePlanner(ctx);
+      if (restored) notify(ctx, 'Prewalk is off and the planner model has been restored.');
+      return;
+    }
+
+    clearAutomation(ctx);
+    notify(ctx, 'Prewalk is off.');
+  }
+
+  pi.registerCommand('prewalk', {
+    description: 'Plan with the current model, make one mutation, then hand off implementation',
+    handler: async (args, ctx) => {
+      if (state.phase === 'idle') refreshConfig();
+      const command = args.trim();
+      if (command === 'status') {
+        publishStatus(ctx);
+        return;
+      }
+      if (command === 'off') {
+        await turnOff(ctx);
+        return;
+      }
+      if (!(await arm(ctx))) return;
+      if (!command) return;
+
+      if (!ctx.hasUI) {
+        beginRun(ctx);
+        if (state.phase !== 'planning') return;
+        pi.sendMessage(
+          {
+            customType: HEADLESS_TASK_MESSAGE_TYPE,
+            content: command,
+            display: true,
+          },
+          { triggerTurn: true },
+        );
+        await ctx.waitForIdle();
+        return;
+      }
+
+      pi.sendUserMessage(command);
+    },
+  });
+
+  pi.on('session_start', (_event, ctx) => {
+    if (state.phase === 'idle') refreshConfig();
+    publishConfigWarning(ctx);
+    updateStatus(ctx);
+  });
+
+  pi.on('before_agent_start', (_event, ctx) => {
+    beginRun(ctx);
+  });
+
+  pi.on('context', (event) => {
+    return { messages: buildContextMessages(event.messages, state.phase, useBeads) as typeof event.messages };
+  });
+
+  pi.on('turn_start', () => {
+    if (state.phase !== 'planning' || !state.run) return;
+    state = { phase: 'planning', run: beginTurn(state.run) };
+  });
+
+  pi.on('tool_call', (event) => {
+    if (state.phase !== 'planning' || !state.run) return;
+
+    if (!useBeads && event.toolName === 'todo_write') {
+      const validation = validateTodoWriteInput(event.input);
+      if (!validation.ok) return { block: true, reason: validation.reason };
+    }
+
+    state = {
+      phase: 'planning',
+      run: recordToolCall(
+        state.run,
+        { toolCallId: event.toolCallId, toolName: event.toolName, input: event.input },
+        useBeads,
+      ),
+    };
+  });
+
+  pi.on('turn_end', async (event, ctx) => {
+    if (state.phase !== 'planning' || !state.run) return;
+
+    const decision = reduceTurn(state.run, event.toolResults, {
+      allowContinuation: isTextOnlyCompletion(event.message),
+    });
+    state = { phase: 'planning', run: decision.state };
+    updateStatus(ctx);
+
+    if (decision.shouldHandoff) {
+      await switchToTarget(ctx);
+      return;
+    }
+
+    if (decision.shouldContinue) {
+      pi.sendMessage(
+        {
+          customType: CONTINUATION_MESSAGE_TYPE,
+          content: '',
+          display: false,
+        },
+        { deliverAs: 'followUp' },
+      );
+    }
+  });
+
+  pi.on('model_select', (event, ctx) => {
+    if (state.phase === 'idle') return;
+
+    const selectedModelKey = modelKey(event.model);
+    if (expectedModelKey === selectedModelKey) {
+      expectedModelKey = undefined;
+      return;
+    }
+
+    clearAutomation(ctx);
+    notify(ctx, `Prewalk cancelled after the model changed to ${selectedModelKey}.`, 'warning');
+  });
+
+  pi.on('agent_settled', async (_event, ctx) => {
+    if (state.phase === 'implementing' || state.phase === 'handoff') {
+      if (config.restorePlanner && plannerSnapshot) {
+        const snapshot = plannerSnapshot;
+        const restored = await restorePlanner(ctx);
+        if (restored) notify(ctx, `Prewalk restored ${snapshot.modelKey}.`);
+      } else {
+        clearAutomation(ctx);
+      }
+      return;
+    }
+
+    if (state.phase === 'planning') {
+      clearAutomation(ctx);
+      notify(ctx, 'Prewalk ended before a qualifying first mutation.', 'warning');
+    }
+  });
+
+  pi.on('session_shutdown', async (_event, ctx) => {
+    const targetIsActive = state.phase === 'handoff'
+      || state.phase === 'implementing'
+      || state.phase === 'restoring';
+    if (targetIsActive && config.restorePlanner && plannerSnapshot) {
+      await restorePlanner(ctx);
+    } else if (state.phase !== 'idle') {
+      clearAutomation(ctx);
+    }
+  });
+};
+
+function buildContextMessages(messages: readonly unknown[], phase: PrewalkPhase, useBeads: boolean): unknown[] {
+  const filtered = structuredClone(messages).filter((message) => !isControlMessage(message));
+  const instruction = phase === 'planning'
+    ? { customType: PLANNING_MESSAGE_TYPE, content: useBeads ? BEADS_PLANNING_INSTRUCTION : PLANNING_INSTRUCTION }
+    : phase === 'implementing'
+      ? {
+          customType: IMPLEMENTATION_MESSAGE_TYPE,
+          content: useBeads ? BEADS_VERIFICATION_INSTRUCTION : VERIFICATION_INSTRUCTION,
+        }
+      : undefined;
+
+  if (!instruction) return filtered;
+
+  return [
+    ...filtered,
+    {
+      role: 'custom',
+      customType: instruction.customType,
+      content: instruction.content,
+      display: false,
+      timestamp: Date.now(),
+    },
+  ];
+}
+
+async function hasBeadsWorkspace(pi: FelanExtensionAPI, cwd: string): Promise<boolean> {
+  try {
+    const result = await pi.runtime.exec(
+      'bd',
+      ['-C', cwd, '--readonly', '--json', 'status', '--no-activity'],
+      { timeout: 5_000 },
+    );
+    return result.code === 0;
+  } catch {
+    return false;
+  }
+}
+
+function isTextOnlyCompletion(message: unknown): boolean {
+  return isRecord(message)
+    && message.role === 'assistant'
+    && message.stopReason === 'stop'
+    && Array.isArray(message.content)
+    && !message.content.some((content) => isRecord(content) && content.type === 'toolCall');
+}
+
+function isControlMessage(message: unknown): boolean {
+  return isRecord(message)
+    && message.role === 'custom'
+    && typeof message.customType === 'string'
+    && message.customType.startsWith(CONTROL_MESSAGE_PREFIX);
+}
+
+function modelKey(model: ExtensionContext['model']): string {
+  return model ? `${model.provider}/${model.id}` : 'none';
+}
+
+function parseTargetModel(value: string): TargetModel | undefined {
+  const separator = value.indexOf('/');
+  if (separator <= 0 || separator === value.length - 1) return undefined;
+
+  const provider = value.slice(0, separator).trim();
+  const modelId = value.slice(separator + 1).trim();
+  if (!provider || !modelId) return undefined;
+
+  return { provider, modelId, key: `${provider}/${modelId}` };
+}
+
+function loadConfig(pi: FelanExtensionAPI): { config: PrewalkConfig; warning?: string } {
+  const targetModel = pi.getFlag(TARGET_MODEL_FLAG);
+  const restorePlanner = pi.getFlag(RESTORE_PLANNER_FLAG);
+  const parsedTarget = typeof targetModel === 'string' ? parseTargetModel(targetModel) : undefined;
+
+  if (!parsedTarget) return invalidConfig(`${TARGET_MODEL_FLAG} must use the form "provider/model-id"`);
+  if (typeof restorePlanner !== 'boolean') return invalidConfig(`${RESTORE_PLANNER_FLAG} must be a boolean`);
+
+  return {
+    config: {
+      targetModel: parsedTarget.key,
+      restorePlanner,
+    },
+  };
+}
+
+function invalidConfig(reason: string): { config: PrewalkConfig; warning: string } {
+  return { config: { ...DEFAULT_CONFIG }, warning: `${reason}.` };
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
 
 export default prewalkExtension;

--- a/packages/ext-prewalk/src/index.ts
+++ b/packages/ext-prewalk/src/index.ts
@@ -429,7 +429,7 @@ function buildContextMessages(messages: readonly unknown[], phase: PrewalkPhase,
 
 async function hasBeadsWorkspace(pi: FelanExtensionAPI, cwd: string): Promise<boolean> {
   try {
-    const result = await pi.runtime.exec(
+    const result = await pi.exec(
       'bd',
       ['-C', cwd, '--readonly', '--json', 'status', '--no-activity'],
       { timeout: 5_000 },

--- a/packages/ext-prewalk/src/prompts.ts
+++ b/packages/ext-prewalk/src/prompts.ts
@@ -1,0 +1,31 @@
+export const CONTROL_MESSAGE_PREFIX = 'pi-prewalk:';
+export const PLANNING_MESSAGE_TYPE = `${CONTROL_MESSAGE_PREFIX}planning`;
+export const IMPLEMENTATION_MESSAGE_TYPE = `${CONTROL_MESSAGE_PREFIX}implementation`;
+export const CONTINUATION_MESSAGE_TYPE = `${CONTROL_MESSAGE_PREFIX}continuation`;
+export const MAX_AUTOMATIC_CONTINUATIONS = 3;
+
+export const PLANNING_INSTRUCTION = `Explore the repository thoroughly and determine the complete work required for the user's request.
+
+Follow this order:
+1. Inspect the relevant source, tests, configuration, documentation, and constraints.
+2. Determine the full implementation scope, affected files and symbols, risks, and verification required.
+3. Call todo_write with 5-9 detailed implementation tasks in execution order. Include validation work and mark exactly one ready task in_progress.
+4. Start implementing immediately. Work through the checklist in order, keep task statuses current, run the relevant validation, and continue until the request is complete.
+
+Keep the implementation focused on the requested scope and revise the checklist when repository evidence changes the plan.`;
+
+export const VERIFICATION_INSTRUCTION = `Continue implementing the existing todo_write checklist in task order. Keep statuses current, complete every remaining item, and keep the changes limited to the requested scope. Run the full relevant test module or suite, resolve failures, and report the verification performed.`;
+
+export const BEADS_PLANNING_INSTRUCTION = `Explore the repository thoroughly and determine the complete work required for the user's request.
+
+Use the beads skill and direct bd CLI commands for task tracking. Track the work with Beads instead of todo_write.
+
+Follow this order:
+1. Inspect the relevant source, tests, configuration, documentation, and constraints.
+2. Determine the full implementation scope, affected files and symbols, risks, and verification required.
+3. Create detailed Beads tasks for all implementation and validation work. Give each task a concrete scope and acceptance criteria, add dependencies that represent the required execution order, and mark the first ready task in_progress.
+4. Start implementing immediately. Work through ready Beads while honoring their dependencies, keep task statuses current, validate each completed task, and continue until every task for the request is complete.
+
+Keep the implementation focused on the requested scope and update the Beads graph when repository evidence changes the plan.`;
+
+export const BEADS_VERIFICATION_INSTRUCTION = `Continue implementing the existing Beads task graph. Honor task dependencies, work through ready Beads in execution order, and keep their statuses current with direct bd CLI commands instead of todo_write. Validate and close each completed Bead, keep the changes limited to the requested scope, run the full relevant test module or suite, resolve failures, and continue until every task is complete.`;

--- a/packages/ext-prewalk/src/state.ts
+++ b/packages/ext-prewalk/src/state.ts
@@ -1,0 +1,181 @@
+import { MAX_AUTOMATIC_CONTINUATIONS } from './prompts.js';
+
+export type PrewalkPhase = 'idle' | 'armed' | 'planning' | 'handoff' | 'implementing' | 'restoring';
+
+export interface PrewalkState {
+  phase: PrewalkPhase;
+  run?: PrewalkRunState;
+}
+
+export interface PrewalkRunState {
+  trackingGateOpen: boolean;
+  toolCalls: RecordedToolCall[];
+  nextOrdinal: number;
+  continuationCount: number;
+  continuationArmed: boolean;
+}
+
+export interface ToolCallSummary {
+  toolCallId: string;
+  toolName: string;
+  input?: unknown;
+}
+
+export interface ToolResultSummary {
+  toolCallId: string;
+  isError: boolean;
+}
+
+export interface TurnDecision {
+  state: PrewalkRunState;
+  shouldHandoff: boolean;
+  shouldContinue: boolean;
+}
+
+export type ValidationResult = { ok: true } | { ok: false; reason: string };
+
+type RecordedToolCall = {
+  toolCallId: string;
+  kind: 'tracking' | 'mutation';
+  ordinal: number;
+};
+
+const MUTATION_TOOLS = ['edit', 'write', 'apply_patch'] as const;
+const TODO_STATUSES = new Set(['pending', 'in_progress', 'completed']);
+
+export const MUTATION_TOOL_NAMES: ReadonlySet<string> = new Set(MUTATION_TOOLS);
+
+export function validateArmingTools(activeTools: readonly string[], useBeads = false): ValidationResult {
+  const missingTracking = useBeads
+    ? !activeTools.some((toolName) => toolName === 'bash' || toolName === 'exec_command')
+    : !activeTools.includes('todo_write');
+  const missingMutation = !activeTools.some((toolName) => MUTATION_TOOL_NAMES.has(toolName));
+
+  if (!missingTracking && !missingMutation) return { ok: true };
+
+  const requirements: string[] = [];
+  if (missingTracking) {
+    requirements.push(useBeads ? 'an active shell tool (bash or exec_command)' : 'the active todo_write tool');
+  }
+  if (missingMutation) requirements.push('an active mutation tool (edit, write, or apply_patch)');
+
+  return {
+    ok: false,
+    reason: `Prewalk requires ${requirements.join(' and ')}.`,
+  };
+}
+
+export function validateTodoWriteInput(input: unknown): ValidationResult {
+  if (!isRecord(input) || !Array.isArray(input.todos)) {
+    return { ok: false, reason: 'Prewalk requires todo_write input with a todos array.' };
+  }
+
+  if (input.todos.length < 5 || input.todos.length > 9) {
+    return { ok: false, reason: 'Prewalk requires 5-9 todo items before the first mutation.' };
+  }
+
+  if (input.todos.some((todo) => !isRecord(todo) || !TODO_STATUSES.has(String(todo.status)))) {
+    return { ok: false, reason: 'Every Prewalk todo must have a valid pending, in_progress, or completed status.' };
+  }
+
+  const inProgressCount = input.todos.filter((todo) => todo.status === 'in_progress').length;
+  if (inProgressCount !== 1) {
+    return { ok: false, reason: 'Prewalk requires exactly one in_progress todo item.' };
+  }
+
+  return { ok: true };
+}
+
+export function createRunState(): PrewalkRunState {
+  return {
+    trackingGateOpen: false,
+    toolCalls: [],
+    nextOrdinal: 0,
+    continuationCount: 0,
+    continuationArmed: true,
+  };
+}
+
+export function beginTurn(state: PrewalkRunState): PrewalkRunState {
+  return {
+    ...state,
+    toolCalls: [],
+    nextOrdinal: 0,
+  };
+}
+
+export function recordToolCall(state: PrewalkRunState, call: ToolCallSummary, useBeads = false): PrewalkRunState {
+  const ordinal = state.nextOrdinal;
+  const nextState = { ...state, nextOrdinal: ordinal + 1 };
+  const kind = isTrackingCall(call, useBeads)
+    ? 'tracking'
+    : MUTATION_TOOL_NAMES.has(call.toolName)
+      ? 'mutation'
+      : undefined;
+
+  if (!kind) return nextState;
+
+  return {
+    ...nextState,
+    toolCalls: [...state.toolCalls, { toolCallId: call.toolCallId, kind, ordinal }],
+  };
+}
+
+export function reduceTurn(
+  state: PrewalkRunState,
+  results: readonly ToolResultSummary[],
+  options: { allowContinuation?: boolean } = {},
+): TurnDecision {
+  const successfulIds = new Set(results.filter((result) => !result.isError).map((result) => result.toolCallId));
+  const successfulTracking = state.toolCalls.filter(
+    (call) => call.kind === 'tracking' && successfulIds.has(call.toolCallId),
+  );
+  const successfulMutations = state.toolCalls.filter(
+    (call) => call.kind === 'mutation' && successfulIds.has(call.toolCallId),
+  );
+
+  const shouldHandoff = state.trackingGateOpen
+    ? successfulMutations.length > 0
+    : successfulMutations.some((mutation) => successfulTracking.some((tracking) => tracking.ordinal < mutation.ordinal));
+
+  let continuationArmed = results.some((result) => !result.isError) || state.continuationArmed;
+  let continuationCount = state.continuationCount;
+  let shouldContinue = false;
+
+  if (
+    !shouldHandoff
+    && options.allowContinuation !== false
+    && results.length === 0
+    && continuationArmed
+    && continuationCount < MAX_AUTOMATIC_CONTINUATIONS
+  ) {
+    shouldContinue = true;
+    continuationCount += 1;
+    continuationArmed = false;
+  }
+
+  return {
+    state: {
+      trackingGateOpen: state.trackingGateOpen || successfulTracking.length > 0,
+      toolCalls: [],
+      nextOrdinal: 0,
+      continuationCount,
+      continuationArmed,
+    },
+    shouldHandoff,
+    shouldContinue,
+  };
+}
+
+function isTrackingCall(call: ToolCallSummary, useBeads: boolean): boolean {
+  if (!useBeads) return call.toolName === 'todo_write';
+  if (call.toolName !== 'bash' && call.toolName !== 'exec_command') return false;
+  if (!isRecord(call.input)) return false;
+  const command = call.input.command ?? call.input.cmd;
+  return typeof command === 'string'
+    && /(?:^|[;&|({}\s])bd\b(?=[^;&|]*\b(?:create|new|q|update|close|done|link|dep|reopen|assign|priority|tag|label|note|comment|edit|set-state)\b)/.test(command);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/packages/ext-prewalk/src/state.ts
+++ b/packages/ext-prewalk/src/state.ts
@@ -42,6 +42,25 @@ type RecordedToolCall = {
 
 const MUTATION_TOOLS = ['edit', 'write', 'apply_patch'] as const;
 const TODO_STATUSES = new Set(['pending', 'in_progress', 'completed']);
+const BEADS_MUTATIONS = new Set([
+  'create',
+  'new',
+  'q',
+  'update',
+  'close',
+  'done',
+  'link',
+  'dep',
+  'reopen',
+  'assign',
+  'priority',
+  'tag',
+  'label',
+  'note',
+  'comment',
+  'edit',
+  'set-state',
+]);
 
 export const MUTATION_TOOL_NAMES: ReadonlySet<string> = new Set(MUTATION_TOOLS);
 
@@ -172,8 +191,81 @@ function isTrackingCall(call: ToolCallSummary, useBeads: boolean): boolean {
   if (call.toolName !== 'bash' && call.toolName !== 'exec_command') return false;
   if (!isRecord(call.input)) return false;
   const command = call.input.command ?? call.input.cmd;
-  return typeof command === 'string'
-    && /(?:^|[;&|({}\s])bd\b(?=[^;&|]*\b(?:create|new|q|update|close|done|link|dep|reopen|assign|priority|tag|label|note|comment|edit|set-state)\b)/.test(command);
+  return typeof command === 'string' && shellCommandSegments(command).some(isBeadsMutationSegment);
+}
+
+function isBeadsMutationSegment(argv: readonly string[]): boolean {
+  const commandIndex = argv.findIndex((argument) => !/^[A-Za-z_][A-Za-z0-9_]*=/.test(argument));
+  if (commandIndex === -1 || argv[commandIndex] !== 'bd') return false;
+
+  return BEADS_MUTATIONS.has(argv[commandIndex + 1] ?? '');
+}
+
+function shellCommandSegments(command: string): string[][] {
+  const segments: string[][] = [];
+  let argv: string[] = [];
+  let token = '';
+  let tokenStarted = false;
+  let quote: "'" | '"' | '`' | undefined;
+
+  const finishToken = () => {
+    if (!tokenStarted) return;
+    argv.push(token);
+    token = '';
+    tokenStarted = false;
+  };
+  const finishSegment = () => {
+    finishToken();
+    if (argv.length > 0) segments.push(argv);
+    argv = [];
+  };
+
+  for (let index = 0; index < command.length; index += 1) {
+    const character = command[index]!;
+
+    if (quote !== undefined) {
+      if (character === quote) {
+        quote = undefined;
+      } else if (character === '\\' && quote !== "'" && index + 1 < command.length) {
+        token += command[index + 1]!;
+        index += 1;
+      } else {
+        token += character;
+      }
+      continue;
+    }
+
+    if (character === "'" || character === '"' || character === '`') {
+      quote = character;
+      tokenStarted = true;
+      continue;
+    }
+    if (character === '\\' && index + 1 < command.length) {
+      token += command[index + 1]!;
+      tokenStarted = true;
+      index += 1;
+      continue;
+    }
+    if (character === '#' && !tokenStarted) {
+      while (index + 1 < command.length && command[index + 1] !== '\n') index += 1;
+      continue;
+    }
+    if (character === ';' || character === '&' || character === '|' || character === '\n') {
+      finishSegment();
+      if ((character === '&' || character === '|') && command[index + 1] === character) index += 1;
+      continue;
+    }
+    if (/\s/.test(character)) {
+      finishToken();
+      continue;
+    }
+
+    token += character;
+    tokenStarted = true;
+  }
+
+  finishSegment();
+  return segments;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/ext-prewalk/tsconfig.build.json
+++ b/packages/ext-prewalk/tsconfig.build.json
@@ -1,5 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": { "rootDir": "src", "outDir": "dist" },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
 
   apps/tui:
     dependencies:
+      '@earendil-works/pi-coding-agent':
+        specifier: 0.82.1
+        version: 0.82.1(ws@8.21.1)(zod@4.4.3)
       '@felan-ai/agent-core':
         specifier: workspace:*
         version: link:../../packages/agent-core
@@ -44,6 +47,9 @@ importers:
       '@earendil-works/pi-coding-agent':
         specifier: 0.82.1
         version: 0.82.1(ws@8.21.1)(zod@4.4.3)
+      typebox:
+        specifier: 1.1.38
+        version: 1.1.38
 
   packages/ext-context:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
 
   packages/ext-powerline:
     dependencies:
+      '@earendil-works/pi-tui':
+        specifier: 0.82.1
+        version: 0.82.1
       '@felan-ai/agent-core':
         specifier: workspace:*
         version: link:../agent-core

--- a/scripts/check-proposed-version.mjs
+++ b/scripts/check-proposed-version.mjs
@@ -1,0 +1,33 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { packagePaths } from './package-paths.mjs';
+
+const root = resolve(import.meta.dirname, '..');
+const rootManifest = JSON.parse(await readFile(resolve(root, 'package.json'), 'utf8'));
+let failed = false;
+
+for (const packagePath of packagePaths) {
+  const manifest = JSON.parse(await readFile(resolve(root, packagePath, 'package.json'), 'utf8'));
+  if (manifest.version !== rootManifest.version) {
+    console.error(`${manifest.name}: version ${manifest.version} differs from proposed ${rootManifest.version}`);
+    failed = true;
+    continue;
+  }
+
+  const url = `https://registry.npmjs.org/${encodeURIComponent(manifest.name)}/${encodeURIComponent(manifest.version)}`;
+  const response = await fetch(url);
+  if (response.status === 404) {
+    console.log(`${manifest.name}@${manifest.version}: available`);
+    continue;
+  }
+  if (response.ok) {
+    console.error(`${manifest.name}@${manifest.version}: already published`);
+  } else {
+    console.error(`${manifest.name}@${manifest.version}: registry returned HTTP ${response.status}`);
+  }
+  failed = true;
+}
+
+if (failed) {
+  process.exit(1);
+}

--- a/scripts/check-release-readiness.mjs
+++ b/scripts/check-release-readiness.mjs
@@ -3,6 +3,7 @@ import { resolve } from 'node:path';
 import { packagePaths } from './package-paths.mjs';
 
 const root = resolve(import.meta.dirname, '..');
+const rootManifest = JSON.parse(await readFile(resolve(root, 'package.json'), 'utf8'));
 const manifests = await Promise.all(
   packagePaths.map(async (packagePath) => ({
     packagePath,
@@ -13,8 +14,11 @@ const manifests = await Promise.all(
 const errors = [];
 const versions = new Set(manifests.map(({ manifest }) => manifest.version));
 
-if (versions.size !== 1) {
-  errors.push('Public packages must use one version');
+if (versions.size !== 1 || [...versions][0] !== rootManifest.version) {
+  errors.push('Root and public packages must use one version');
+}
+if (!/^\d+\.\d+\.\d+-[0-9A-Za-z.-]+$/.test(rootManifest.version)) {
+  errors.push('Root version must be a prerelease version');
 }
 
 for (const { packagePath, manifest } of manifests) {
@@ -57,6 +61,36 @@ if (!release.includes('id-token: write') || !release.includes('--provenance')) {
 if (/NODE_AUTH_TOKEN|NPM_TOKEN|npmrc.*_authToken/i.test(release)) {
   errors.push('Release workflow must not use registry credentials');
 }
+if (!release.includes("- 'v*-*'") || !release.includes('--tag next')) {
+  errors.push('Release workflow must publish only prerelease tags to the next dist-tag');
+}
+
+const expectedOrder = [
+  'packages/agent-core',
+  'packages/ext-context',
+  'packages/ext-prewalk',
+  'packages/ext-powerline',
+  'apps/tui',
+];
+if (packagePaths.join('\n') !== expectedOrder.join('\n')) {
+  errors.push('Package order must be Agent Core, extensions, then TUI');
+}
+const publishArtifacts = [
+  'felan-ai-agent-core-${version}.tgz',
+  'felan-ai-ext-context-${version}.tgz',
+  'felan-ai-ext-prewalk-${version}.tgz',
+  'felan-ai-ext-powerline-${version}.tgz',
+  'felan-ai-felan-${version}.tgz',
+];
+let previousArtifact = -1;
+for (const artifact of publishArtifacts) {
+  const artifactIndex = release.indexOf(artifact);
+  if (artifactIndex <= previousArtifact) {
+    errors.push('Release workflow must publish Agent Core, extensions, then TUI');
+    break;
+  }
+  previousArtifact = artifactIndex;
+}
 
 if (errors.length > 0) {
   for (const error of errors) {
@@ -65,4 +99,4 @@ if (errors.length > 0) {
   process.exit(1);
 }
 
-console.log(`Release metadata valid for ${manifests.length} public packages at ${[...versions][0]}`);
+console.log(`Release metadata valid for ${manifests.length} public packages at ${rootManifest.version}`);

--- a/scripts/package-paths.mjs
+++ b/scripts/package-paths.mjs
@@ -1,7 +1,7 @@
 export const packagePaths = [
-  'apps/tui',
   'packages/agent-core',
   'packages/ext-context',
   'packages/ext-prewalk',
   'packages/ext-powerline',
+  'apps/tui',
 ];

--- a/scripts/test-packed-bin.mjs
+++ b/scripts/test-packed-bin.mjs
@@ -1,0 +1,55 @@
+import { mkdtempSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { delimiter, join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const root = resolve(import.meta.dirname, '..');
+const artifacts = resolve(root, '.artifacts');
+const installDir = mkdtempSync(join(tmpdir(), 'felan-packed-bin-'));
+const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const felan = join(installDir, 'node_modules', '.bin', process.platform === 'win32' ? 'felan.cmd' : 'felan');
+
+try {
+  const tarballs = readdirSync(artifacts)
+    .filter((entry) => entry.endsWith('.tgz'))
+    .map((entry) => join(artifacts, entry));
+  if (tarballs.length !== 5) {
+    throw new Error(`Expected 5 packed artifacts, found ${tarballs.length}`);
+  }
+
+  run(npm, [
+    'install',
+    '--ignore-scripts',
+    '--no-audit',
+    '--no-fund',
+    '--prefix',
+    installDir,
+    ...tarballs,
+  ]);
+
+  const result = run(felan, ['--diagnostics'], {
+    ...process.env,
+    PATH: `${join(installDir, 'node_modules', '.bin')}${delimiter}${process.env.PATH ?? ''}`,
+  });
+  for (const expected of ['Felan version:', 'Agent Core version:', 'Pi version:', 'Runtime: host']) {
+    if (!result.stdout.includes(expected)) {
+      throw new Error(`Packed felan --diagnostics output is missing ${JSON.stringify(expected)}`);
+    }
+  }
+} finally {
+  rmSync(installDir, { recursive: true, force: true });
+}
+
+function run(command, args, env = process.env) {
+  const result = spawnSync(command, args, {
+    cwd: root,
+    encoding: 'utf8',
+    env,
+  });
+  if (result.status !== 0) {
+    process.stderr.write(result.stdout);
+    process.stderr.write(result.stderr);
+    throw new Error(`${command} exited with status ${result.status ?? 'unknown'}`);
+  }
+  return result;
+}

--- a/scripts/test-packed-bin.mjs
+++ b/scripts/test-packed-bin.mjs
@@ -1,4 +1,11 @@
-import { mkdtempSync, readdirSync, rmSync } from 'node:fs';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { delimiter, join, resolve } from 'node:path';
 import { spawnSync } from 'node:child_process';
@@ -6,10 +13,32 @@ import { spawnSync } from 'node:child_process';
 const root = resolve(import.meta.dirname, '..');
 const artifacts = resolve(root, '.artifacts');
 const installDir = mkdtempSync(join(tmpdir(), 'felan-packed-bin-'));
+const cleanHome = join(installDir, 'home');
 const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
 const felan = join(installDir, 'node_modules', '.bin', process.platform === 'win32' ? 'felan.cmd' : 'felan');
+const packageNames = [
+  '@felan-ai/agent-core',
+  '@felan-ai/ext-context',
+  '@felan-ai/ext-prewalk',
+  '@felan-ai/ext-powerline',
+  '@felan-ai/felan',
+];
+const proposedVersion = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8')).version;
+const cleanEnvironment = Object.fromEntries(
+  Object.entries(process.env).filter(([name]) => !/(TOKEN|API_KEY|AUTH|PASSWORD|SECRET)/i.test(name)),
+);
+Object.assign(cleanEnvironment, {
+  HOME: cleanHome,
+  USERPROFILE: cleanHome,
+  NPM_CONFIG_REGISTRY: 'https://registry.npmjs.org/',
+  NPM_CONFIG_USERCONFIG: join(cleanHome, '.npmrc'),
+  PATH: `${join(installDir, 'node_modules', '.bin')}${delimiter}${process.env.PATH ?? ''}`,
+});
 
 try {
+  mkdirSync(cleanHome);
+  writeFileSync(join(cleanHome, '.npmrc'), 'registry=https://registry.npmjs.org/\n');
+
   const tarballs = readdirSync(artifacts)
     .filter((entry) => entry.endsWith('.tgz'))
     .map((entry) => join(artifacts, entry));
@@ -25,16 +54,44 @@ try {
     '--prefix',
     installDir,
     ...tarballs,
-  ]);
+  ], cleanEnvironment);
 
-  const result = run(felan, ['--diagnostics'], {
-    ...process.env,
-    PATH: `${join(installDir, 'node_modules', '.bin')}${delimiter}${process.env.PATH ?? ''}`,
-  });
-  for (const expected of ['Felan version:', 'Agent Core version:', 'Pi version:', 'Runtime: host']) {
+  for (const packageName of packageNames) {
+    const manifest = JSON.parse(readFileSync(
+      join(installDir, 'node_modules', ...packageName.split('/'), 'package.json'),
+      'utf8',
+    ));
+    if (manifest.version !== proposedVersion) {
+      throw new Error(`${packageName} packed version is ${manifest.version}, expected ${proposedVersion}`);
+    }
+    for (const [dependency, version] of Object.entries(manifest.dependencies ?? {})) {
+      if (dependency.startsWith('@felan-ai/') && version !== proposedVersion) {
+        throw new Error(`${packageName} packed dependency ${dependency} is ${version}, expected ${proposedVersion}`);
+      }
+    }
+  }
+
+  run(process.execPath, [
+    '--input-type=module',
+    '--eval',
+    `await Promise.all(${JSON.stringify([...packageNames, '@felan-ai/agent-core/runtime-test-kit'])}.map((name) => import(name)))`,
+  ], cleanEnvironment);
+
+  const result = run(felan, ['--diagnostics'], cleanEnvironment);
+  for (const expected of [
+    `Felan version: ${proposedVersion}`,
+    `Agent Core version: ${proposedVersion}`,
+    'Pi version:',
+    'Runtime: host',
+    'Credentials: local',
+  ]) {
     if (!result.stdout.includes(expected)) {
       throw new Error(`Packed felan --diagnostics output is missing ${JSON.stringify(expected)}`);
     }
+  }
+  const versionResult = run(felan, ['--version'], cleanEnvironment);
+  if (versionResult.stdout.trim() !== proposedVersion) {
+    throw new Error(`Packed felan --version reported ${JSON.stringify(versionResult.stdout.trim())}`);
   }
 } finally {
   rmSync(installDir, { recursive: true, force: true });
@@ -42,7 +99,7 @@ try {
 
 function run(command, args, env = process.env) {
   const result = spawnSync(command, args, {
-    cwd: root,
+    cwd: installDir,
     encoding: 'utf8',
     env,
   });


### PR DESCRIPTION
## Summary
- add the account-free local `felan` InteractiveMode application over Agent Core and host runtime
- migrate progressive context and Prewalk from `workspace/pi-extensions` into runtime-aware public packages
- add the local-only portable powerline extension
- prepare the fixed public package group for `0.1.0-alpha.2`

## Verification
- Node.js 22.20.0
- `pnpm check:release`
- `pnpm check:proposed-version`
- `pnpm verify` (148 tests)
- clean packed install/import/bin/TUI smoke without private credentials
- forbidden extension import boundary scans

## Release boundary
This PR prepares the public prerelease only. Stable publication and production activation remain blocked by the upstream Pi shrinkwrap vulnerability.