### PR TITLE
chore: add cross-repository release gates

### DIFF
--- a/.github/workflows/stable-readiness.yml
+++ b/.github/workflows/stable-readiness.yml
@@ -1,0 +1,31 @@
+name: Stable release readiness
+
+on:
+  workflow_dispatch:
+    inputs:
+      cli-package:
+        description: Packed tarball URL/path or published @felan-ai/cli spec with the felan-cli binary
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.20.0
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm verify
+      - run: pnpm audit:packed
+      - run: pnpm test:co-install -- --cli "$CLI_PACKAGE"
+        env:
+          CLI_PACKAGE: ${{ inputs.cli-package }}

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,9 @@
 MIT License
 
 Copyright (c) 2026 Felan contributors
+Copyright (c) 2026 Dimitar Panayotov
+Copyright (c) 2026 Marc Krenn
+Copyright (c) 2026 Milko Slavov
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/NOTICE
+++ b/NOTICE
@@ -1,16 +1,30 @@
 Felan
 Copyright (c) 2026 Felan contributors
 
-This product includes software developed by the Pi project and other open
-source projects listed in the package lockfile. Their license terms remain
-with their respective authors.
+This product uses Pi 0.82.1 from https://github.com/earendil-works/pi,
+licensed under the MIT License. Copyright (c) 2025 Mario Zechner.
+
+@felan-ai/agent-core uses TypeBox 1.1.38 from
+https://github.com/sinclairzx81/typebox, licensed under the MIT License.
+Copyright (c) 2017-2026 Haydn Paterson.
+
+Other third-party runtime dependencies are identified by exact version and
+integrity in pnpm-lock.yaml and retain their respective license terms.
+
+@felan-ai/ext-context adapts MIT-licensed portions of
+packages/pi-progressive-context from https://github.com/mslavov/pi-extensions
+at commit 9571293d422db11de893fa80ed0fc3e39945c657.
+Copyright (c) 2026 Milko Slavov.
 
 @felan-ai/ext-prewalk adapts MIT-licensed portions of packages/pi-prewalk from
 mslavov/pi-extensions at commit 7e72e509fe45a5a87c4c2e176cb711de994a8c1d.
 Copyright (c) 2026 Dimitar Panayotov and Milko Slavov. Package-level attribution
 and license terms are included in packages/ext-prewalk/NOTICE and LICENSE.
 
-@felan-ai/ext-powerline contains code adapted from the MIT-licensed
-pi-powerline source by Milko Slavov. The source credits the MIT-licensed
-marckrenn/pi-sub packages/sub-core for subscription provider and usage logic;
-Felan excludes its credential loading and subscription network implementation.
+@felan-ai/ext-powerline adapts MIT-licensed portions of packages/pi-powerline
+from https://github.com/mslavov/pi-extensions at commit
+7e72e509fe45a5a87c4c2e176cb711de994a8c1d. Copyright (c) 2026 Milko Slavov.
+That source credits the MIT-licensed packages/sub-core from
+https://github.com/marckrenn/pi-sub for subscription provider and usage logic.
+Copyright (c) 2026 Marc Krenn. Felan excludes its credential loading and
+subscription network implementation.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ After installation, run `felan` for the interactive local agent or
 through the TUI and do not require a Felan account.
 
 See [Contributing](CONTRIBUTING.md) and [Release process](docs/releasing.md).
+The release process includes packed clean-install, clean audit, extension
+boundary, and parameterized `felan`/`felan-cli` co-installation gates.
 
 ## License
 

--- a/apps/tui/NOTICE
+++ b/apps/tui/NOTICE
@@ -1,0 +1,11 @@
+@felan-ai/felan
+
+Copyright (c) 2026 Felan contributors
+
+This package composes the MIT-licensed @felan-ai/agent-core and Felan extension
+packages listed in package.json. Their package-level LICENSE and NOTICE files
+contain the applicable attribution and source provenance.
+
+The terminal application uses @earendil-works/pi-coding-agent 0.82.1 from
+https://github.com/earendil-works/pi, licensed under the MIT License.
+Copyright (c) 2025 Mario Zechner.

--- a/apps/tui/README.md
+++ b/apps/tui/README.md
@@ -32,3 +32,14 @@ felan --diagnostics
 ```
 
 Diagnostics include the Felan, Agent Core, Pi, and Node.js versions.
+
+## Development
+
+Source: `apps/tui` in <https://github.com/felan-ai/felan>.
+
+```sh
+corepack enable
+pnpm install --frozen-lockfile
+pnpm --filter @felan-ai/felan build
+pnpm --filter @felan-ai/felan test
+```

--- a/apps/tui/package.json
+++ b/apps/tui/package.json
@@ -4,13 +4,18 @@
   "description": "Local Felan terminal agent",
   "license": "MIT",
   "type": "module",
-  "repository": "github:felan-ai/felan",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/felan-ai/felan.git",
+    "directory": "apps/tui"
+  },
   "engines": {
     "node": ">=22.19.0"
   },
   "files": [
     "dist",
     "LICENSE",
+    "NOTICE",
     "README.md"
   ],
   "bin": {

--- a/apps/tui/package.json
+++ b/apps/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felan-ai/felan",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.3",
   "description": "Local Felan terminal agent",
   "license": "MIT",
   "type": "module",

--- a/apps/tui/src/extensions.ts
+++ b/apps/tui/src/extensions.ts
@@ -6,16 +6,11 @@ export const localExtensionPackages = [
   '@felan-ai/ext-powerline',
 ] as const;
 
-const localExtensionImporters: Record<string, () => Promise<unknown>> = {
-  '@felan-ai/ext-prewalk': () => import('@felan-ai/ext-prewalk'),
-  '@felan-ai/ext-context': () => import('@felan-ai/ext-context'),
-  '@felan-ai/ext-powerline': () => import('@felan-ai/ext-powerline'),
-};
+const localExtensionPackageSet: ReadonlySet<string> = new Set(localExtensionPackages);
 
 export const importLocalExtension: ExtensionPackageImporter = async (packageName) => {
-  const importExtension = localExtensionImporters[packageName];
-  if (!importExtension) {
+  if (!localExtensionPackageSet.has(packageName)) {
     throw new Error(`Unknown local extension package: ${packageName}`);
   }
-  return importExtension();
+  return import(packageName);
 };

--- a/apps/tui/test/cli.test.ts
+++ b/apps/tui/test/cli.test.ts
@@ -12,8 +12,8 @@ describe('felan CLI', () => {
     });
 
     expect(exitCode).toBe(0);
-    expect(FELAN_VERSION).toBe('0.1.0-alpha.2');
-    expect(AGENT_CORE_VERSION).toBe('0.1.0-alpha.2');
+    expect(FELAN_VERSION).toBe('0.1.0-alpha.3');
+    expect(AGENT_CORE_VERSION).toBe('0.1.0-alpha.3');
     expect(output).toContain(`Felan version: ${FELAN_VERSION}`);
     expect(output).toContain(`Agent Core version: ${AGENT_CORE_VERSION}`);
     expect(output).toContain('Runtime: host');

--- a/apps/tui/test/extensions.test.ts
+++ b/apps/tui/test/extensions.test.ts
@@ -14,8 +14,10 @@ describe('local extension importer', () => {
         default: expect.any(Function),
       });
     }
-    await expect(importLocalExtension('@felan-ai/ambient')).rejects.toThrow(
-      'Unknown local extension package: @felan-ai/ambient',
-    );
+    for (const packageName of ['@felan-ai/agent-core', '@felan-ai/ambient']) {
+      await expect(importLocalExtension(packageName)).rejects.toThrow(
+        `Unknown local extension package: ${packageName}`,
+      );
+    }
   });
 });

--- a/docs/package-availability.md
+++ b/docs/package-availability.md
@@ -1,6 +1,7 @@
 # Public package names
 
-The credentials-free `pnpm check:packages` command queries npmjs for:
+The credentials-free `pnpm check:packages` command derives the public package
+names from `scripts/package-paths.mjs` and queries npmjs for:
 
 - `@felan-ai/agent-core`
 - `@felan-ai/ext-context`

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -5,7 +5,7 @@ trusted publishing and provenance. The workflow has an OIDC identity token and
 contains no npm credential. It packs workspace dependencies with pnpm and uses
 an OIDC-capable npm 11 CLI to publish the resulting tarballs.
 
-The current combined S7-S10 prerelease version is `0.1.0-alpha.2`. The root and
+The current release-readiness prerelease version is `0.1.0-alpha.3`. The root and
 all five public manifests form one fixed version group. Agent Core diagnostics
 report the same package-derived version.
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -19,11 +19,37 @@ Before a prerelease:
    `pnpm verify`, so ordinary CI remains valid after publication.
 4. Run `pnpm verify` on Node.js 22.20.0. The packed smoke installs with a clean
    npm configuration, checks exact workspace dependency versions, imports every
-   public package, and runs the `felan` binary without private credentials.
+   public package through the installed application, constructs a local runtime,
+   rejects unlisted packages, and runs the `felan` binary without credentials.
 5. Configure each npm package's trusted publisher for this repository and workflow.
 6. Create the matching prerelease `v<version>` tag through the normal reviewed
    release process. The workflow publishes in dependency order: Agent Core,
    extensions, then TUI, all with the npm `next` dist-tag.
 
-Stable publication follows successful prerelease integration with public host and
-private cloud runtime adapters.
+## Stable readiness
+
+Stable publication follows successful prerelease integration with public host
+and private cloud runtime adapters. Run the validation-only **Stable release
+readiness** workflow with a packed tarball or published package spec for the
+Story 11 `@felan-ai/cli` release. The workflow performs:
+
+```sh
+pnpm install --frozen-lockfile
+pnpm verify
+pnpm audit:packed
+pnpm test:co-install -- --cli <tarball-or-@felan-ai/cli@version>
+```
+
+`test:co-install` uses the packed TUI set in `.artifacts` by default. It also
+accepts `--tui <tarball-or-package-spec>` and the `FELAN_CLI_PACKAGE` and
+`FELAN_TUI_PACKAGE` environment variables. It uses no sibling checkout and
+requires the platform CLI to expose only `felan-cli` while the local TUI exposes
+only `felan`.
+
+The clean audit currently reports the vulnerable `brace-expansion@5.0.7`
+locked by the published Pi 0.82.1 shrinkwrap. Pi has no safe compatible npm
+release yet. Stable publication remains blocked by `bugzy-3bfl.16`; the exact
+Pi 0.82.1 pin remains unchanged until a reviewed upstream release is available.
+
+The stable gate also requires the renamed platform CLI publication. The current
+public `@felan-ai/cli@0.1.0` still exposes `felan`, so it is not a valid input.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "felan",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.3",
   "private": true,
   "description": "Portable Felan agent core, extensions, and local TUI",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "type-check": "pnpm -r --if-present type-check",
     "test": "pnpm -r --if-present test",
     "test:packed-bin": "node scripts/test-packed-bin.mjs",
+    "audit:packed": "node scripts/test-packed-bin.mjs --audit",
+    "test:co-install": "node scripts/test-product-coinstall.mjs",
     "pack:all": "node scripts/pack.mjs",
     "check:packages": "node scripts/check-package-availability.mjs",
     "check:proposed-version": "node scripts/check-proposed-version.mjs",

--- a/packages/agent-core/NOTICE
+++ b/packages/agent-core/NOTICE
@@ -1,0 +1,11 @@
+@felan-ai/agent-core
+
+Copyright (c) 2026 Felan contributors
+
+This package uses @earendil-works/pi-coding-agent 0.82.1 and its Pi runtime
+packages from https://github.com/earendil-works/pi, licensed under the MIT
+License. Copyright (c) 2025 Mario Zechner.
+
+This package uses TypeBox 1.1.38 from
+https://github.com/sinclairzx81/typebox, licensed under the MIT License.
+Copyright (c) 2017-2026 Haydn Paterson.

--- a/packages/agent-core/README.md
+++ b/packages/agent-core/README.md
@@ -36,3 +36,14 @@ changing shared agent behavior.
 Applications may pass an explicit `skills` list into session composition.
 Agent Core exposes only that list while project, user, and package skill
 discovery remain disabled.
+
+## Development
+
+Source: `packages/agent-core` in <https://github.com/felan-ai/felan>.
+
+```sh
+corepack enable
+pnpm install --frozen-lockfile
+pnpm --filter @felan-ai/agent-core build
+pnpm --filter @felan-ai/agent-core test
+```

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felan-ai/agent-core",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.3",
   "description": "Portable Felan agent contracts and composition",
   "license": "MIT",
   "type": "module",

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -4,13 +4,18 @@
   "description": "Portable Felan agent contracts and composition",
   "license": "MIT",
   "type": "module",
-  "repository": "github:felan-ai/felan",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/felan-ai/felan.git",
+    "directory": "packages/agent-core"
+  },
   "engines": {
     "node": ">=22.19.0"
   },
   "files": [
     "dist",
     "LICENSE",
+    "NOTICE",
     "README.md"
   ],
   "exports": {

--- a/packages/ext-context/LICENSE
+++ b/packages/ext-context/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2026 Felan contributors
+Copyright (c) 2026 Milko Slavov
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/ext-context/NOTICE
+++ b/packages/ext-context/NOTICE
@@ -1,7 +1,8 @@
 @felan-ai/ext-context
 
-Includes code adapted from pi-progressive-context in the pi-extensions
-repository (git@github.com:mslavov/pi-extensions.git), source commit 9571293.
+Includes code adapted from packages/pi-progressive-context in
+https://github.com/mslavov/pi-extensions at source commit
+9571293d422db11de893fa80ed0fc3e39945c657.
 
 Copyright (c) 2026 Milko Slavov
 Licensed under the MIT License included in this package.

--- a/packages/ext-context/README.md
+++ b/packages/ext-context/README.md
@@ -25,6 +25,17 @@ symlink escapes.
 Use `/progressive-context` to show the nested instruction files loaded in the
 current session.
 
+## Development
+
+Source: `packages/ext-context` in <https://github.com/felan-ai/felan>.
+
+```sh
+corepack enable
+pnpm install --frozen-lockfile
+pnpm --filter @felan-ai/ext-context build
+pnpm --filter @felan-ai/ext-context test
+```
+
 ## Trigger limitations
 
 - Progressive context affects the model call after a file read or attachment.

--- a/packages/ext-context/package.json
+++ b/packages/ext-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felan-ai/ext-context",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.3",
   "description": "Progressive-context extension for Felan",
   "license": "MIT",
   "type": "module",

--- a/packages/ext-context/package.json
+++ b/packages/ext-context/package.json
@@ -4,7 +4,11 @@
   "description": "Progressive-context extension for Felan",
   "license": "MIT",
   "type": "module",
-  "repository": "github:felan-ai/felan",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/felan-ai/felan.git",
+    "directory": "packages/ext-context"
+  },
   "engines": {
     "node": ">=22.19.0"
   },

--- a/packages/ext-powerline/LICENSE
+++ b/packages/ext-powerline/LICENSE
@@ -1,6 +1,8 @@
 MIT License
 
 Copyright (c) 2026 Felan contributors
+Copyright (c) 2026 Marc Krenn
+Copyright (c) 2026 Milko Slavov
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/ext-powerline/NOTICE
+++ b/packages/ext-powerline/NOTICE
@@ -1,10 +1,13 @@
 @felan-ai/ext-powerline
 
-Portions of this package are adapted from the MIT-licensed pi-powerline source
-by Milko Slavov.
+Portions of this package are adapted from packages/pi-powerline in
+https://github.com/mslavov/pi-extensions at commit
+7e72e509fe45a5a87c4c2e176cb711de994a8c1d.
+Copyright (c) 2026 Milko Slavov.
 
-The pi-powerline source credits marckrenn/pi-sub packages/sub-core, licensed
-under the MIT License, for subscription provider and usage logic. Felan does
-not include the credential loading or subscription network implementation.
+The pi-powerline source credits packages/sub-core from
+https://github.com/marckrenn/pi-sub, licensed under the MIT License, for
+subscription provider and usage logic. Copyright (c) 2026 Marc Krenn. Felan
+does not include the credential loading or subscription network implementation.
 
 All adaptations remain available under the MIT License in LICENSE.

--- a/packages/ext-powerline/README.md
+++ b/packages/ext-powerline/README.md
@@ -43,7 +43,11 @@ private environment conventions.
 
 ## Development
 
+Source: `packages/ext-powerline` in <https://github.com/felan-ai/felan>.
+
 ```sh
+corepack enable
+pnpm install --frozen-lockfile
 pnpm --filter @felan-ai/ext-powerline build
 pnpm --filter @felan-ai/ext-powerline type-check
 pnpm --filter @felan-ai/ext-powerline test

--- a/packages/ext-powerline/package.json
+++ b/packages/ext-powerline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felan-ai/ext-powerline",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.3",
   "description": "Terminal powerline extension for Felan",
   "license": "MIT",
   "type": "module",

--- a/packages/ext-powerline/package.json
+++ b/packages/ext-powerline/package.json
@@ -4,7 +4,11 @@
   "description": "Terminal powerline extension for Felan",
   "license": "MIT",
   "type": "module",
-  "repository": "github:felan-ai/felan",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/felan-ai/felan.git",
+    "directory": "packages/ext-powerline"
+  },
   "engines": {
     "node": ">=22.19.0"
   },

--- a/packages/ext-prewalk/NOTICE
+++ b/packages/ext-prewalk/NOTICE
@@ -1,7 +1,8 @@
 @felan-ai/ext-prewalk
 
 This package includes adapted portions of packages/pi-prewalk from
-mslavov/pi-extensions at commit 7e72e509fe45a5a87c4c2e176cb711de994a8c1d.
+https://github.com/mslavov/pi-extensions at commit
+7e72e509fe45a5a87c4c2e176cb711de994a8c1d.
 
 Copyright (c) 2026 Dimitar Panayotov
 Copyright (c) 2026 Milko Slavov

--- a/packages/ext-prewalk/README.md
+++ b/packages/ext-prewalk/README.md
@@ -57,6 +57,17 @@ Prewalk uses Pi's namespaced extension flags and does not read a configuration f
 - Session quit, reload, replacement, or fork while the target is active attempts planner restoration as a graceful shutdown backstop.
 - Reaching the automatic continuation limit lets the run settle normally.
 
+## Development
+
+Source: `packages/ext-prewalk` in <https://github.com/felan-ai/felan>.
+
+```sh
+corepack enable
+pnpm install --frozen-lockfile
+pnpm --filter @felan-ai/ext-prewalk build
+pnpm --filter @felan-ai/ext-prewalk test
+```
+
 ## Attribution
 
 This package adapts the MIT-licensed `packages/pi-prewalk` implementation from `mslavov/pi-extensions` at commit `7e72e509fe45a5a87c4c2e176cb711de994a8c1d`. See [NOTICE](./NOTICE) and [LICENSE](./LICENSE).

--- a/packages/ext-prewalk/package.json
+++ b/packages/ext-prewalk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felan-ai/ext-prewalk",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.3",
   "description": "Same-session planner-to-implementation model handoff for Felan",
   "license": "MIT",
   "type": "module",

--- a/packages/ext-prewalk/package.json
+++ b/packages/ext-prewalk/package.json
@@ -4,7 +4,11 @@
   "description": "Same-session planner-to-implementation model handoff for Felan",
   "license": "MIT",
   "type": "module",
-  "repository": "github:felan-ai/felan",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/felan-ai/felan.git",
+    "directory": "packages/ext-prewalk"
+  },
   "engines": {
     "node": ">=22.19.0"
   },

--- a/scripts/check-package-availability.mjs
+++ b/scripts/check-package-availability.mjs
@@ -1,10 +1,11 @@
-const packageNames = [
-  '@felan-ai/agent-core',
-  '@felan-ai/ext-context',
-  '@felan-ai/ext-prewalk',
-  '@felan-ai/ext-powerline',
-  '@felan-ai/felan',
-];
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { packagePaths } from './package-paths.mjs';
+
+const root = resolve(import.meta.dirname, '..');
+const packageNames = await Promise.all(packagePaths.map(async (packagePath) => (
+  JSON.parse(await readFile(resolve(root, packagePath, 'package.json'), 'utf8')).name
+)));
 
 let failed = false;
 

--- a/scripts/check-release-readiness.mjs
+++ b/scripts/check-release-readiness.mjs
@@ -1,102 +1,288 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
-import { resolve } from 'node:path';
+import { join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
 import { packagePaths } from './package-paths.mjs';
 
+const NODE_ENGINE = '>=22.19.0';
+const NODE_PIN = '22.20.0';
+const PI_VERSION = '0.82.1';
+const PI_PACKAGES = [
+  '@earendil-works/pi-agent-core',
+  '@earendil-works/pi-ai',
+  '@earendil-works/pi-coding-agent',
+  '@earendil-works/pi-tui',
+];
+const REQUIRED_PACKAGE_FILES = ['dist', 'LICENSE', 'NOTICE', 'README.md'];
 const root = resolve(import.meta.dirname, '..');
-const rootManifest = JSON.parse(await readFile(resolve(root, 'package.json'), 'utf8'));
-const manifests = await Promise.all(
-  packagePaths.map(async (packagePath) => ({
-    packagePath,
-    manifest: JSON.parse(await readFile(resolve(root, packagePath, 'package.json'), 'utf8')),
-  })),
-);
-
+const rootManifest = await manifestAt('.');
+const packages = await Promise.all(packagePaths.map(async (packagePath) => ({
+  packagePath,
+  manifest: await manifestAt(packagePath),
+})));
 const errors = [];
-const versions = new Set(manifests.map(({ manifest }) => manifest.version));
 
-if (versions.size !== 1 || [...versions][0] !== rootManifest.version) {
-  errors.push('Root and public packages must use one version');
-}
-if (!/^\d+\.\d+\.\d+-[0-9A-Za-z.-]+$/.test(rootManifest.version)) {
-  errors.push('Root version must be a prerelease version');
-}
-
-for (const { packagePath, manifest } of manifests) {
-  if (!manifest.name?.startsWith('@felan-ai/')) {
-    errors.push(`${packagePath}: package name must use the @felan-ai scope`);
-  }
-  if (manifest.license !== 'MIT') {
-    errors.push(`${packagePath}: license must be MIT`);
-  }
-  if (manifest.engines?.node !== '>=22.19.0') {
-    errors.push(`${packagePath}: Node engine must be >=22.19.0`);
-  }
-  if (manifest.repository !== 'github:felan-ai/felan') {
-    errors.push(`${packagePath}: repository metadata is missing`);
-  }
-  if (manifest.publishConfig?.access !== 'public' || manifest.publishConfig?.provenance !== true) {
-    errors.push(`${packagePath}: public provenance publishing is required`);
-  }
-}
-
-const agentCore = manifests.find(({ manifest }) => manifest.name === '@felan-ai/agent-core')?.manifest;
-if (agentCore?.dependencies?.['@earendil-works/pi-coding-agent'] !== '0.82.1') {
-  errors.push('@felan-ai/agent-core must pin Pi coding agent 0.82.1 exactly');
-}
-
-const nodeVersion = (await readFile(resolve(root, '.node-version'), 'utf8')).trim();
-if (nodeVersion !== '22.20.0') {
-  errors.push('.node-version must be 22.20.0');
-}
-
-const ci = await readFile(resolve(root, '.github/workflows/ci.yml'), 'utf8');
-if (!ci.includes('node-version: 22.20.0')) {
-  errors.push('CI must pin Node.js 22.20.0');
-}
-
-const release = await readFile(resolve(root, '.github/workflows/release.yml'), 'utf8');
-if (!release.includes('id-token: write') || !release.includes('--provenance')) {
-  errors.push('Release workflow must use npm provenance through OIDC');
-}
-if (/NODE_AUTH_TOKEN|NPM_TOKEN|npmrc.*_authToken/i.test(release)) {
-  errors.push('Release workflow must not use registry credentials');
-}
-if (!release.includes("- 'v*-*'") || !release.includes('--tag next')) {
-  errors.push('Release workflow must publish only prerelease tags to the next dist-tag');
-}
-
-const expectedOrder = [
-  'packages/agent-core',
-  'packages/ext-context',
-  'packages/ext-prewalk',
-  'packages/ext-powerline',
-  'apps/tui',
-];
-if (packagePaths.join('\n') !== expectedOrder.join('\n')) {
-  errors.push('Package order must be Agent Core, extensions, then TUI');
-}
-const publishArtifacts = [
-  'felan-ai-agent-core-${version}.tgz',
-  'felan-ai-ext-context-${version}.tgz',
-  'felan-ai-ext-prewalk-${version}.tgz',
-  'felan-ai-ext-powerline-${version}.tgz',
-  'felan-ai-felan-${version}.tgz',
-];
-let previousArtifact = -1;
-for (const artifact of publishArtifacts) {
-  const artifactIndex = release.indexOf(artifact);
-  if (artifactIndex <= previousArtifact) {
-    errors.push('Release workflow must publish Agent Core, extensions, then TUI');
-    break;
-  }
-  previousArtifact = artifactIndex;
-}
+checkPackageInventory();
+checkPackageMetadata();
+checkDependencies();
+checkExtensionComposition();
+checkExtensionBoundaries();
+checkPinsAndWorkflows();
+checkRepositoryBoundary();
+checkLegalProvenance();
 
 if (errors.length > 0) {
-  for (const error of errors) {
-    console.error(error);
-  }
+  for (const error of errors) console.error(error);
   process.exit(1);
 }
 
-console.log(`Release metadata valid for ${manifests.length} public packages at ${rootManifest.version}`);
+console.log(`Release boundaries valid for ${packages.length} public packages at ${rootManifest.version}`);
+
+function checkPackageInventory() {
+  const discovered = ['apps', 'packages'].flatMap((parent) => (
+    readdirSync(resolve(root, parent), { withFileTypes: true })
+      .filter((entry) => entry.isDirectory() && existsSync(resolve(root, parent, entry.name, 'package.json')))
+      .map((entry) => `${parent}/${entry.name}`)
+  )).sort();
+  const listed = [...packagePaths].sort();
+  if (discovered.join('\n') !== listed.join('\n')) {
+    errors.push(`Public package list differs from workspace manifests: ${discovered.join(', ')}`);
+  }
+
+  const names = packages.map(({ manifest }) => manifest.name);
+  if (new Set(names).size !== names.length) errors.push('Public package names must be unique');
+  if (packages.at(-1)?.manifest.name !== '@felan-ai/felan') {
+    errors.push('@felan-ai/felan must pack after Agent Core and extensions');
+  }
+}
+
+function checkPackageMetadata() {
+  const versions = new Set(packages.map(({ manifest }) => manifest.version));
+  if (versions.size !== 1 || [...versions][0] !== rootManifest.version) {
+    errors.push('Root and public packages must use one version');
+  }
+  if (!/^\d+\.\d+\.\d+-[0-9A-Za-z.-]+$/.test(rootManifest.version)) {
+    errors.push('Root version must be a prerelease version');
+  }
+
+  for (const { packagePath, manifest } of packages) {
+    if (!manifest.name?.startsWith('@felan-ai/')) {
+      errors.push(`${packagePath}: package name must use the @felan-ai scope`);
+    }
+    if (manifest.private === true) errors.push(`${packagePath}: public package cannot be private`);
+    if (manifest.license !== 'MIT') errors.push(`${packagePath}: license must be MIT`);
+    if (manifest.engines?.node !== NODE_ENGINE) {
+      errors.push(`${packagePath}: Node engine must be ${NODE_ENGINE}`);
+    }
+    if (
+      manifest.repository?.type !== 'git'
+      || manifest.repository?.url !== 'git+https://github.com/felan-ai/felan.git'
+      || manifest.repository?.directory !== packagePath
+    ) {
+      errors.push(`${packagePath}: repository metadata must identify its public source directory`);
+    }
+    if (manifest.publishConfig?.access !== 'public' || manifest.publishConfig?.provenance !== true) {
+      errors.push(`${packagePath}: public provenance publishing is required`);
+    }
+    for (const requiredFile of REQUIRED_PACKAGE_FILES) {
+      if (!manifest.files?.includes(requiredFile)) {
+        errors.push(`${packagePath}: packed files must include ${requiredFile}`);
+      }
+    }
+  }
+}
+
+function checkDependencies() {
+  for (const { packagePath, manifest } of packages) {
+    for (const section of ['dependencies', 'optionalDependencies', 'peerDependencies']) {
+      for (const [name, specifier] of Object.entries(manifest[section] ?? {})) {
+        if (name.startsWith('@felan-cloud/')) {
+          errors.push(`${packagePath}: public package depends on private package ${name}`);
+        }
+        if (/^(?:file|link|portal|git|git\+|https?|github|bitbucket):|^\.{0,2}\//.test(specifier)) {
+          errors.push(`${packagePath}: ${name} uses non-registry dependency ${specifier}`);
+        }
+        if (name.startsWith('@felan-ai/')) {
+          if (specifier !== 'workspace:*') {
+            errors.push(`${packagePath}: internal source dependency ${name} must use workspace:*`);
+          }
+        } else if (specifier.startsWith('workspace:')) {
+          errors.push(`${packagePath}: external dependency ${name} cannot use a workspace specifier`);
+        } else if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(specifier)) {
+          errors.push(`${packagePath}: production dependency ${name} must use an exact version`);
+        }
+        if (name.startsWith('@earendil-works/pi-') && specifier !== PI_VERSION) {
+          errors.push(`${packagePath}: ${name} must pin ${PI_VERSION} exactly`);
+        }
+      }
+    }
+    if (manifest.bundledDependencies || manifest.bundleDependencies) {
+      errors.push(`${packagePath}: bundled dependencies are not allowed`);
+    }
+  }
+}
+
+function checkExtensionComposition() {
+  const tui = packages.find(({ manifest }) => manifest.name === '@felan-ai/felan');
+  if (!tui) return;
+  const source = readFileSync(resolve(root, 'apps/tui/src/extensions.ts'), 'utf8');
+  const listBody = source.match(/localExtensionPackages\s*=\s*\[([\s\S]*?)\]\s*as const/)?.[1] ?? '';
+  const listed = [...listBody.matchAll(/['"](@felan-ai\/ext-[^'"]+)['"]/g)].map((match) => match[1]);
+  const dependencies = Object.keys(tui.manifest.dependencies ?? {})
+    .filter((name) => name.startsWith('@felan-ai/ext-'));
+
+  if ([...listed].sort().join('\n') !== [...dependencies].sort().join('\n')) {
+    errors.push('apps/tui: extension list must equal direct extension dependencies');
+  }
+  if (new Set(listed).size !== listed.length) errors.push('apps/tui: extension list contains duplicates');
+  if (!source.includes('return import(packageName);')) {
+    errors.push('apps/tui: extension importer must preserve app-anchored native dynamic import');
+  }
+  if (/import\(\s*['"]@felan-ai\/ext-/.test(source)) {
+    errors.push('apps/tui: extension importer cannot contain extension-specific imports');
+  }
+
+  const coreSources = sourceFiles(resolve(root, 'packages/agent-core/src'))
+    .map((path) => readFileSync(path, 'utf8')).join('\n');
+  if (/@felan-ai\/ext-/.test(coreSources)) {
+    errors.push('@felan-ai/agent-core cannot import or name a concrete extension package');
+  }
+}
+
+function checkExtensionBoundaries() {
+  for (const { packagePath } of packages.filter(({ manifest }) => manifest.name.startsWith('@felan-ai/ext-'))) {
+    for (const path of sourceFiles(resolve(root, packagePath, 'src'))) {
+      const source = readFileSync(path, 'utf8');
+      if (/['"]node:(?:fs|fs\/promises|child_process)['"]|from\s+['"](?:fs|fs\/promises|child_process)['"]/.test(source)) {
+        errors.push(`${relativePath(path)}: extensions must use AgentRuntime instead of filesystem/process modules`);
+      }
+      if (/\b(?:exec|execFile|spawn|fork|writeFile|readFile|rm|unlink)Sync\s*\(|\b(?:Bun|Deno)\.(?:spawn|write|read|remove)\s*\(/.test(source)) {
+        errors.push(`${relativePath(path)}: extensions cannot perform direct process or filesystem effects`);
+      }
+    }
+  }
+}
+
+function checkPinsAndWorkflows() {
+  if (rootManifest.packageManager !== 'pnpm@9.15.5') errors.push('pnpm must pin 9.15.5 exactly');
+  if (rootManifest.engines?.node !== NODE_ENGINE) errors.push(`Root Node engine must be ${NODE_ENGINE}`);
+  if (readFileSync(resolve(root, '.node-version'), 'utf8').trim() !== NODE_PIN) {
+    errors.push(`.node-version must be ${NODE_PIN}`);
+  }
+  for (const packageName of PI_PACKAGES) {
+    if (rootManifest.pnpm?.overrides?.[packageName] !== PI_VERSION) {
+      errors.push(`Root override ${packageName} must pin ${PI_VERSION}`);
+    }
+  }
+
+  const lockfile = readFileSync(resolve(root, 'pnpm-lock.yaml'), 'utf8');
+  const lockPackages = lockfile.split('\npackages:\n')[1]?.split('\nsnapshots:\n')[0] ?? '';
+  for (const packageName of PI_PACKAGES) {
+    const resolved = [...lockPackages.matchAll(new RegExp(`^  ['"]?${escapeRegExp(packageName)}@([^:'"]+)['"]?:`, 'gm'))]
+      .map((match) => match[1]);
+    if (resolved.length !== 1 || resolved[0] !== PI_VERSION) {
+      errors.push(`Lockfile must resolve exactly one ${packageName}@${PI_VERSION}`);
+    }
+  }
+
+  const ci = readFileSync(resolve(root, '.github/workflows/ci.yml'), 'utf8');
+  if (!ci.includes(`node-version: ${NODE_PIN}`) || !ci.includes('pnpm install --frozen-lockfile')) {
+    errors.push(`CI must pin Node.js ${NODE_PIN} and use the frozen lockfile`);
+  }
+  const release = readFileSync(resolve(root, '.github/workflows/release.yml'), 'utf8');
+  if (!release.includes(`node-version: ${NODE_PIN}`)) errors.push(`Release must pin Node.js ${NODE_PIN}`);
+  if (!release.includes('id-token: write') || !release.includes('--provenance')) {
+    errors.push('Release workflow must use npm provenance through OIDC');
+  }
+  if (/NODE_AUTH_TOKEN|NPM_TOKEN|npmrc.*_authToken/i.test(release)) {
+    errors.push('Release workflow must not use registry credentials');
+  }
+  if (!release.includes("- 'v*-*'") || !release.includes('--tag next')) {
+    errors.push('Release workflow must publish only prerelease tags to the next dist-tag');
+  }
+
+  let previousArtifact = -1;
+  for (const { manifest } of packages) {
+    const artifact = `${manifest.name.slice(1).replace('/', '-')}-\${version}.tgz`;
+    const artifactIndex = release.indexOf(artifact);
+    if (artifactIndex <= previousArtifact) {
+      errors.push('Release workflow must publish every package in package-list order');
+      break;
+    }
+    previousArtifact = artifactIndex;
+  }
+
+  const stable = readFileSync(resolve(root, '.github/workflows/stable-readiness.yml'), 'utf8');
+  for (const requirement of [
+    `node-version: ${NODE_PIN}`,
+    'pnpm install --frozen-lockfile',
+    'pnpm verify',
+    'pnpm audit:packed',
+    'pnpm test:co-install',
+  ]) {
+    if (!stable.includes(requirement)) errors.push(`Stable readiness workflow is missing ${requirement}`);
+  }
+  if (/npm publish|pnpm publish|git push/.test(stable)) {
+    errors.push('Stable readiness workflow must be validation-only');
+  }
+}
+
+function checkRepositoryBoundary() {
+  const npmrc = readFileSync(resolve(root, '.npmrc'), 'utf8');
+  if (!npmrc.includes('registry=https://registry.npmjs.org/')) {
+    errors.push('.npmrc must default public packages to npmjs');
+  }
+  if (/^@[^:]+:registry=/m.test(npmrc) || /github\.com\/.*packages|npm\.pkg\.github\.com/i.test(npmrc)) {
+    errors.push('.npmrc cannot map public packages to a private registry');
+  }
+  if (existsSync(resolve(root, '.gitmodules'))) errors.push('Git submodules are not allowed');
+  const gitIndex = spawnSync('git', ['ls-files', '--stage'], { cwd: root, encoding: 'utf8' });
+  if (gitIndex.status !== 0) errors.push('Unable to inspect Git index for submodules');
+  if (/^160000 /m.test(gitIndex.stdout)) errors.push('Gitlink/submodule entries are not allowed');
+
+  for (const { packagePath } of packages) {
+    const manifestSource = readFileSync(resolve(root, packagePath, 'package.json'), 'utf8');
+    if (/@felan-cloud\/|npm\.pkg\.github\.com|felan-platform\/apps\/agent/.test(manifestSource)) {
+      errors.push(`${packagePath}: private package, registry, or copied-source reference is not allowed`);
+    }
+  }
+}
+
+function checkLegalProvenance() {
+  const requiredNotices = new Map([
+    ['packages/ext-context/NOTICE', '9571293d422db11de893fa80ed0fc3e39945c657'],
+    ['packages/ext-prewalk/NOTICE', '7e72e509fe45a5a87c4c2e176cb711de994a8c1d'],
+    ['packages/ext-powerline/NOTICE', '7e72e509fe45a5a87c4c2e176cb711de994a8c1d'],
+  ]);
+  for (const [path, sourceCommit] of requiredNotices) {
+    const notice = readFileSync(resolve(root, path), 'utf8');
+    if (!notice.includes('https://github.com/') || !notice.includes(sourceCommit)) {
+      errors.push(`${path}: NOTICE must include public source URL and full source commit`);
+    }
+  }
+  for (const { packagePath } of packages) {
+    const license = readFileSync(resolve(root, packagePath, 'LICENSE'), 'utf8');
+    if (!license.startsWith('MIT License')) errors.push(`${packagePath}: package LICENSE must contain MIT text`);
+    const readme = readFileSync(resolve(root, packagePath, 'README.md'), 'utf8');
+    if (!readme.includes('## Development')) errors.push(`${packagePath}: README must include source build instructions`);
+  }
+}
+
+async function manifestAt(packagePath) {
+  return JSON.parse(await readFile(resolve(root, packagePath, 'package.json'), 'utf8'));
+}
+
+function sourceFiles(directory) {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name);
+    return entry.isDirectory() ? sourceFiles(path) : entry.isFile() && entry.name.endsWith('.ts') ? [path] : [];
+  });
+}
+
+function relativePath(path) {
+  return path.slice(root.length + 1);
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/scripts/test-packed-bin.mjs
+++ b/scripts/test-packed-bin.mjs
@@ -1,4 +1,5 @@
 import {
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readdirSync,
@@ -9,92 +10,166 @@ import {
 import { tmpdir } from 'node:os';
 import { delimiter, join, resolve } from 'node:path';
 import { spawnSync } from 'node:child_process';
+import { packagePaths } from './package-paths.mjs';
 
 const root = resolve(import.meta.dirname, '..');
 const artifacts = resolve(root, '.artifacts');
 const installDir = mkdtempSync(join(tmpdir(), 'felan-packed-bin-'));
 const cleanHome = join(installDir, 'home');
+const cacheDir = join(installDir, 'npm-cache');
+const workspace = join(installDir, 'workspace');
+const agentDir = join(cleanHome, '.felan', 'agent');
 const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
-const felan = join(installDir, 'node_modules', '.bin', process.platform === 'win32' ? 'felan.cmd' : 'felan');
-const packageNames = [
-  '@felan-ai/agent-core',
-  '@felan-ai/ext-context',
-  '@felan-ai/ext-prewalk',
-  '@felan-ai/ext-powerline',
-  '@felan-ai/felan',
-];
+const binDirectory = join(installDir, 'node_modules', '.bin');
+const felan = join(binDirectory, process.platform === 'win32' ? 'felan.cmd' : 'felan');
 const proposedVersion = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8')).version;
+const sourcePackages = packagePaths.map((packagePath) => JSON.parse(
+  readFileSync(resolve(root, packagePath, 'package.json'), 'utf8'),
+));
+const packageNames = sourcePackages.map(({ name }) => name);
+const audit = process.argv.includes('--audit');
 const cleanEnvironment = Object.fromEntries(
-  Object.entries(process.env).filter(([name]) => !/(TOKEN|API_KEY|AUTH|PASSWORD|SECRET)/i.test(name)),
+  Object.entries(process.env).filter(([name]) => (
+    !/(TOKEN|API_KEY|AUTH|PASSWORD|SECRET|CREDENTIAL|COOKIE|SESSION|(^|_)KEY$)/i.test(name)
+  )),
 );
 Object.assign(cleanEnvironment, {
   HOME: cleanHome,
   USERPROFILE: cleanHome,
+  NPM_CONFIG_CACHE: cacheDir,
   NPM_CONFIG_REGISTRY: 'https://registry.npmjs.org/',
   NPM_CONFIG_USERCONFIG: join(cleanHome, '.npmrc'),
-  PATH: `${join(installDir, 'node_modules', '.bin')}${delimiter}${process.env.PATH ?? ''}`,
+  PATH: `${binDirectory}${delimiter}${process.env.PATH ?? ''}`,
+  FELAN_AGENT_DIR: agentDir,
+  PACKED_SMOKE_WORKSPACE: workspace,
 });
 
 try {
   mkdirSync(cleanHome);
+  mkdirSync(workspace);
   writeFileSync(join(cleanHome, '.npmrc'), 'registry=https://registry.npmjs.org/\n');
 
   const tarballs = readdirSync(artifacts)
     .filter((entry) => entry.endsWith('.tgz'))
     .map((entry) => join(artifacts, entry));
-  if (tarballs.length !== 5) {
-    throw new Error(`Expected 5 packed artifacts, found ${tarballs.length}`);
+  if (tarballs.length !== sourcePackages.length) {
+    throw new Error(`Expected ${sourcePackages.length} packed artifacts, found ${tarballs.length}`);
   }
 
   run(npm, [
     'install',
     '--ignore-scripts',
-    '--no-audit',
     '--no-fund',
     '--prefix',
     installDir,
     ...tarballs,
   ], cleanEnvironment);
 
-  for (const packageName of packageNames) {
-    const manifest = JSON.parse(readFileSync(
-      join(installDir, 'node_modules', ...packageName.split('/'), 'package.json'),
-      'utf8',
-    ));
-    if (manifest.version !== proposedVersion) {
-      throw new Error(`${packageName} packed version is ${manifest.version}, expected ${proposedVersion}`);
-    }
-    for (const [dependency, version] of Object.entries(manifest.dependencies ?? {})) {
-      if (dependency.startsWith('@felan-ai/') && version !== proposedVersion) {
-        throw new Error(`${packageName} packed dependency ${dependency} is ${version}, expected ${proposedVersion}`);
-      }
-    }
-  }
+  for (const sourcePackage of sourcePackages) validateInstalledPackage(sourcePackage);
 
   run(process.execPath, [
     '--input-type=module',
     '--eval',
-    `await Promise.all(${JSON.stringify([...packageNames, '@felan-ai/agent-core/runtime-test-kit'])}.map((name) => import(name)))`,
+    `
+      const packageNames = ${JSON.stringify([...packageNames, '@felan-ai/agent-core/runtime-test-kit'])};
+      await Promise.all(packageNames.map((name) => import(name)));
+      const app = await import('@felan-ai/felan');
+      for (const packageName of app.localExtensionPackages) {
+        const extension = await app.importLocalExtension(packageName);
+        if (typeof extension.default !== 'function') throw new Error(packageName + ' has no extension factory');
+      }
+      for (const packageName of ['@felan-ai/agent-core', '@felan-ai/unlisted-extension']) {
+        try {
+          await app.importLocalExtension(packageName);
+          throw new Error(packageName + ' loaded without a list entry');
+        } catch (error) {
+          if (!String(error).includes('Unknown local extension package')) throw error;
+        }
+      }
+      const runtime = await app.createLocalFelanRuntime({
+        cwd: process.env.PACKED_SMOKE_WORKSPACE,
+        agentDir: process.env.FELAN_AGENT_DIR,
+      });
+      await runtime.dispose();
+    `,
   ], cleanEnvironment);
 
-  const result = run(felan, ['--diagnostics'], cleanEnvironment);
+  const diagnostics = run(felan, ['--diagnostics'], cleanEnvironment);
   for (const expected of [
     `Felan version: ${proposedVersion}`,
     `Agent Core version: ${proposedVersion}`,
-    'Pi version:',
+    'Pi version: 0.82.1',
     'Runtime: host',
     'Credentials: local',
   ]) {
-    if (!result.stdout.includes(expected)) {
+    if (!diagnostics.stdout.includes(expected)) {
       throw new Error(`Packed felan --diagnostics output is missing ${JSON.stringify(expected)}`);
     }
+  }
+  const help = run(felan, ['--help'], cleanEnvironment);
+  if (!help.stdout.includes('Usage: felan [options] [message]')) {
+    throw new Error('Packed felan --help did not start the local TUI CLI');
   }
   const versionResult = run(felan, ['--version'], cleanEnvironment);
   if (versionResult.stdout.trim() !== proposedVersion) {
     throw new Error(`Packed felan --version reported ${JSON.stringify(versionResult.stdout.trim())}`);
   }
+  const authPath = join(agentDir, 'auth.json');
+  if (existsSync(authPath) && Object.keys(JSON.parse(readFileSync(authPath, 'utf8'))).length > 0) {
+    throw new Error('Credential-free packed smoke unexpectedly loaded model credentials');
+  }
+
+  if (audit) {
+    run(npm, ['audit', '--audit-level=high', '--prefix', installDir], cleanEnvironment);
+  }
 } finally {
   rmSync(installDir, { recursive: true, force: true });
+}
+
+function validateInstalledPackage(sourcePackage) {
+  const packageRoot = join(installDir, 'node_modules', ...sourcePackage.name.split('/'));
+  const manifest = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf8'));
+  if (manifest.version !== proposedVersion) {
+    throw new Error(`${manifest.name} packed version is ${manifest.version}, expected ${proposedVersion}`);
+  }
+  if (
+    manifest.repository?.url !== 'git+https://github.com/felan-ai/felan.git'
+    || manifest.repository?.directory !== sourcePackage.repository.directory
+  ) {
+    throw new Error(`${manifest.name} packed manifest lost public source provenance`);
+  }
+  for (const requiredFile of ['LICENSE', 'NOTICE', 'README.md']) {
+    if (!existsSync(join(packageRoot, requiredFile))) {
+      throw new Error(`${manifest.name} packed artifact is missing ${requiredFile}`);
+    }
+  }
+  if (!existsSync(join(packageRoot, 'dist'))) {
+    throw new Error(`${manifest.name} packed artifact is missing dist`);
+  }
+  for (const entry of readdirSync(packageRoot)) {
+    if (!['dist', 'LICENSE', 'NOTICE', 'README.md', 'package.json'].includes(entry)) {
+      throw new Error(`${manifest.name} packed unexpected top-level entry ${entry}`);
+    }
+  }
+
+  for (const [dependency, version] of Object.entries(manifest.dependencies ?? {})) {
+    if (dependency.startsWith('@felan-ai/') && version !== proposedVersion) {
+      throw new Error(`${manifest.name} packed dependency ${dependency} is ${version}, expected ${proposedVersion}`);
+    }
+    if (dependency.startsWith('@felan-cloud/')) {
+      throw new Error(`${manifest.name} packed private dependency ${dependency}`);
+    }
+    if (/workspace:|^(?:file|link|portal|git|git\+|https?|github|bitbucket):|^\.{0,2}\//.test(version)) {
+      throw new Error(`${manifest.name} packed non-registry dependency ${dependency}@${version}`);
+    }
+  }
+
+  if (manifest.name === '@felan-ai/felan') {
+    const extensionSource = readFileSync(join(packageRoot, 'dist', 'extensions.js'), 'utf8');
+    if (!/import\(packageName\)/.test(extensionSource)) {
+      throw new Error('Packed TUI did not preserve its app-anchored native dynamic importer');
+    }
+  }
 }
 
 function run(command, args, env = process.env) {

--- a/scripts/test-product-coinstall.mjs
+++ b/scripts/test-product-coinstall.mjs
@@ -1,0 +1,131 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { delimiter, isAbsolute, join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const root = resolve(import.meta.dirname, '..');
+const installDir = mkdtempSync(join(tmpdir(), 'felan-product-coinstall-'));
+const cleanHome = join(installDir, 'home');
+const binDirectory = join(installDir, 'node_modules', '.bin');
+const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const cliSpec = option('--cli') ?? process.env.FELAN_CLI_PACKAGE;
+const tuiSpec = option('--tui') ?? process.env.FELAN_TUI_PACKAGE;
+
+if (!cliSpec) {
+  console.error('Pass --cli <tarball-or-package-spec> or set FELAN_CLI_PACKAGE');
+  process.exit(2);
+}
+
+const cleanEnvironment = Object.fromEntries(
+  Object.entries(process.env).filter(([name]) => (
+    !/(TOKEN|API_KEY|AUTH|PASSWORD|SECRET|CREDENTIAL|COOKIE|SESSION|(^|_)KEY$)/i.test(name)
+  )),
+);
+Object.assign(cleanEnvironment, {
+  HOME: cleanHome,
+  USERPROFILE: cleanHome,
+  NPM_CONFIG_CACHE: join(installDir, 'npm-cache'),
+  NPM_CONFIG_REGISTRY: 'https://registry.npmjs.org/',
+  NPM_CONFIG_USERCONFIG: join(cleanHome, '.npmrc'),
+  PATH: `${binDirectory}${delimiter}${process.env.PATH ?? ''}`,
+  FELAN_AGENT_DIR: join(cleanHome, '.felan', 'agent'),
+});
+
+try {
+  mkdirSync(cleanHome);
+  writeFileSync(join(cleanHome, '.npmrc'), 'registry=https://registry.npmjs.org/\n');
+  const tuiPackages = tuiSpec ? [normalizeSpec(tuiSpec)] : packedTuiSet();
+  run(npm, [
+    'install',
+    '--ignore-scripts',
+    '--no-fund',
+    '--prefix',
+    installDir,
+    normalizeSpec(cliSpec),
+    ...tuiPackages,
+  ]);
+
+  const cliManifest = installedManifest('@felan-ai/cli');
+  const tuiManifest = installedManifest('@felan-ai/felan');
+  if (JSON.stringify(cliManifest.bin) !== JSON.stringify({ 'felan-cli': 'dist/cli.js' })) {
+    throw new Error(`@felan-ai/cli must expose only felan-cli; received ${JSON.stringify(cliManifest.bin)}`);
+  }
+  if (JSON.stringify(tuiManifest.bin) !== JSON.stringify({ felan: './dist/cli.js' })) {
+    throw new Error(`@felan-ai/felan must expose only felan; received ${JSON.stringify(tuiManifest.bin)}`);
+  }
+
+  const felan = binary('felan');
+  const felanCli = binary('felan-cli');
+  if (!existsSync(felan) || !existsSync(felanCli) || felan === felanCli) {
+    throw new Error('felan and felan-cli must coexist as distinct binaries');
+  }
+  const tuiHelp = run(felan, ['--help']);
+  if (!tuiHelp.stdout.includes('Usage: felan ')) throw new Error('felan TUI help smoke failed');
+  const cliHelp = run(felanCli, ['--help']);
+  if (!/felan-cli|Usage:/i.test(cliHelp.stdout + cliHelp.stderr)) {
+    throw new Error('felan-cli help smoke failed');
+  }
+} finally {
+  rmSync(installDir, { recursive: true, force: true });
+}
+
+function option(name) {
+  const index = process.argv.indexOf(name);
+  if (index === -1) return undefined;
+  const value = process.argv[index + 1];
+  if (!value || value.startsWith('--')) throw new Error(`${name} requires a value`);
+  return value;
+}
+
+function packedTuiSet() {
+  const artifacts = resolve(root, '.artifacts');
+  if (!existsSync(artifacts)) throw new Error('Run pnpm pack:all before the packed co-install smoke');
+  const tarballs = readdirSync(artifacts)
+    .filter((entry) => entry.endsWith('.tgz'))
+    .map((entry) => join(artifacts, entry));
+  if (tarballs.length === 0) throw new Error('No packed TUI package set found in .artifacts');
+  return tarballs;
+}
+
+function normalizeSpec(spec) {
+  if (spec.startsWith('-')) throw new Error(`Package spec cannot start with '-': ${spec}`);
+  if (/^https?:\/\//.test(spec)) return spec;
+  if (spec.startsWith('.') || spec.startsWith('/') || spec.endsWith('.tgz')) {
+    return isAbsolute(spec) ? spec : resolve(process.cwd(), spec);
+  }
+  return spec;
+}
+
+function installedManifest(packageName) {
+  const path = join(installDir, 'node_modules', ...packageName.split('/'), 'package.json');
+  if (!existsSync(path)) throw new Error(`${packageName} was not installed`);
+  const manifest = JSON.parse(readFileSync(path, 'utf8'));
+  if (manifest.name !== packageName) throw new Error(`${path} contains ${manifest.name}`);
+  return manifest;
+}
+
+function binary(name) {
+  return join(binDirectory, process.platform === 'win32' ? `${name}.cmd` : name);
+}
+
+function run(command, args) {
+  const result = spawnSync(command, args, {
+    cwd: installDir,
+    encoding: 'utf8',
+    env: cleanEnvironment,
+  });
+  if (result.status !== 0) {
+    process.stderr.write(result.stdout);
+    process.stderr.write(result.stderr);
+    throw new Error(`${command} exited with status ${result.status ?? 'unknown'}`);
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary
- add public artifact, package-list, importer, legal, provenance, and runtime-boundary gates
- preserve a generic app-anchored extension importer and reject unlisted packages
- add credential-free packed TUI and `felan`/`felan-cli` co-install validation
- prepare the fixed `0.1.0-alpha.3` prerelease for final private candidate integration

## Verification
- `pnpm verify` (148 tests, five packs, clean installed-package/TUI smoke)
- `pnpm check:proposed-version`
- `pnpm test:co-install -- --cli @felan-ai/cli@0.2.0`
- actionlint

`pnpm audit:packed` remains intentionally blocked by the tracked upstream Pi shrinkwrap issue; no override or audit bypass is introduced.