### PR TITLE
ci: harden stable package promotion

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release prerelease packages
 on:
   push:
     tags:
-      - 'v*-*'
+      - 'v*'
 
 permissions:
   contents: read
@@ -15,6 +15,8 @@ jobs:
     environment: npm
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: pnpm/action-setup@v4
         with:
           version: 9.15.5
@@ -26,7 +28,30 @@ jobs:
       - run: pnpm verify
       - run: pnpm check:proposed-version
       - run: npm install --global npm@11.19.0
-      - run: test "${GITHUB_REF_NAME#v}" = "$(node -p 'require("./package.json").version')"
+      - name: Verify release identity
+        id: release
+        run: |
+          set -euo pipefail
+          version=$(node -p 'require("./package.json").version')
+          test "${GITHUB_REF_NAME#v}" = "$version"
+          git fetch origin main
+          git merge-base --is-ancestor "$(git rev-parse "$GITHUB_SHA^{commit}")" origin/main
+          if [[ "$version" == *-* ]]; then
+            echo 'channel=next' >> "$GITHUB_OUTPUT"
+            echo 'stable=false' >> "$GITHUB_OUTPUT"
+          else
+            echo 'channel=latest' >> "$GITHUB_OUTPUT"
+            echo 'stable=true' >> "$GITHUB_OUTPUT"
+          fi
+      - name: Verify stable candidate evidence
+        if: steps.release.outputs.stable == 'true'
+        run: pnpm check:stable-evidence
+      - name: Audit stable packed closure
+        if: steps.release.outputs.stable == 'true'
+        run: pnpm audit:packed
+      - name: Verify stable product co-install
+        if: steps.release.outputs.stable == 'true'
+        run: pnpm test:co-install -- --cli @felan-ai/cli@0.2.0
       - run: |
           version="$(node -p 'require("./package.json").version')"
           for package in \
@@ -36,5 +61,5 @@ jobs:
             ".artifacts/felan-ai-ext-powerline-${version}.tgz" \
             ".artifacts/felan-ai-felan-${version}.tgz"
           do
-            npm publish "$package" --access public --tag next --provenance
+            npm publish "$package" --access public --tag "${{ steps.release.outputs.channel }}" --provenance
           done

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -14,15 +14,17 @@ Before a prerelease:
 1. Run `pnpm check:packages` to verify each public package name on npmjs.
 2. Run `pnpm check:release` to validate the fixed version group, prerelease tag
    policy, OIDC provenance, and topological pack/publish order.
-3. Run `pnpm check:proposed-version` to confirm the exact proposed version is
+3. Run `pnpm check:licenses` to reject unknown, private, or non-permissive
+   production dependencies and verify the Pi and TypeBox notices.
+4. Run `pnpm check:proposed-version` to confirm the exact proposed version is
    unused for every public package. This preparation-only check stays outside
    `pnpm verify`, so ordinary CI remains valid after publication.
-4. Run `pnpm verify` on Node.js 22.20.0. The packed smoke installs with a clean
+5. Run `pnpm verify` on Node.js 22.20.0. The packed smoke installs with a clean
    npm configuration, checks exact workspace dependency versions, imports every
    public package through the installed application, constructs a local runtime,
    rejects unlisted packages, and runs the `felan` binary without credentials.
-5. Configure each npm package's trusted publisher for this repository and workflow.
-6. Create the matching prerelease `v<version>` tag through the normal reviewed
+6. Configure each npm package's trusted publisher for this repository and workflow.
+7. Create the matching prerelease `v<version>` tag through the normal reviewed
    release process. The workflow publishes in dependency order: Agent Core,
    extensions, then TUI, all with the npm `next` dist-tag.
 
@@ -51,5 +53,9 @@ locked by the published Pi 0.82.1 shrinkwrap. Pi has no safe compatible npm
 release yet. Stable publication remains blocked by `bugzy-3bfl.16`; the exact
 Pi 0.82.1 pin remains unchanged until a reviewed upstream release is available.
 
-The stable gate also requires the renamed platform CLI publication. The current
-public `@felan-ai/cli@0.1.0` still exposes `felan`, so it is not a valid input.
+The stable gate requires published `@felan-ai/cli@0.2.0`, which exposes only
+`felan-cli`, plus `release-evidence/<stable-version>.json` copied from the
+successful private trusted-candidate record. The evidence binds the exact
+prerelease versions, integrities, public tag and commit, private candidate run,
+and tested private commit. `pnpm check:stable-evidence` revalidates every public
+npm provenance statement before a stable tag can publish to `latest`.

--- a/package.json
+++ b/package.json
@@ -18,9 +18,11 @@
     "test:co-install": "node scripts/test-product-coinstall.mjs",
     "pack:all": "node scripts/pack.mjs",
     "check:packages": "node scripts/check-package-availability.mjs",
+    "check:licenses": "node scripts/check-third-party-licenses.mjs",
     "check:proposed-version": "node scripts/check-proposed-version.mjs",
     "check:release": "node scripts/check-release-readiness.mjs",
-    "verify": "pnpm check:release && pnpm build && pnpm type-check && pnpm test && pnpm pack:all && pnpm test:packed-bin"
+    "check:stable-evidence": "node scripts/check-stable-evidence.mjs",
+    "verify": "pnpm check:release && pnpm check:licenses && pnpm build && pnpm type-check && pnpm test && pnpm pack:all && pnpm test:packed-bin"
   },
   "devDependencies": {
     "@types/node": "24.12.4",

--- a/scripts/check-release-readiness.mjs
+++ b/scripts/check-release-readiness.mjs
@@ -61,8 +61,8 @@ function checkPackageMetadata() {
   if (versions.size !== 1 || [...versions][0] !== rootManifest.version) {
     errors.push('Root and public packages must use one version');
   }
-  if (!/^\d+\.\d+\.\d+-[0-9A-Za-z.-]+$/.test(rootManifest.version)) {
-    errors.push('Root version must be a prerelease version');
+  if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(rootManifest.version)) {
+    errors.push('Root version must be exact semver');
   }
 
   for (const { packagePath, manifest } of packages) {
@@ -197,8 +197,15 @@ function checkPinsAndWorkflows() {
   if (/NODE_AUTH_TOKEN|NPM_TOKEN|npmrc.*_authToken/i.test(release)) {
     errors.push('Release workflow must not use registry credentials');
   }
-  if (!release.includes("- 'v*-*'") || !release.includes('--tag next')) {
-    errors.push('Release workflow must publish only prerelease tags to the next dist-tag');
+  for (const requirement of [
+    "- 'v*'",
+    'git merge-base --is-ancestor',
+    'pnpm check:stable-evidence',
+    'pnpm audit:packed',
+    'pnpm test:co-install',
+    'steps.release.outputs.channel',
+  ]) {
+    if (!release.includes(requirement)) errors.push(`Release workflow is missing ${requirement}`);
   }
 
   let previousArtifact = -1;

--- a/scripts/check-stable-evidence.mjs
+++ b/scripts/check-stable-evidence.mjs
@@ -1,0 +1,82 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { packagePaths } from './package-paths.mjs';
+
+const root = resolve(import.meta.dirname, '..');
+const stableVersion = JSON.parse(await readFile(resolve(root, 'package.json'), 'utf8')).version;
+if (!/^\d+\.\d+\.\d+$/.test(stableVersion)) {
+  throw new Error(`Stable evidence requires a stable version; received ${stableVersion}`);
+}
+const evidencePath = resolve(root, 'release-evidence', `${stableVersion}.json`);
+const evidence = JSON.parse(await readFile(evidencePath, 'utf8'));
+const packageNames = await Promise.all(packagePaths.map(async (packagePath) => (
+  JSON.parse(await readFile(resolve(root, packagePath, 'package.json'), 'utf8')).name
+)));
+
+if (evidence.stableVersion !== stableVersion) throw new Error('Evidence stableVersion does not match');
+if (!/^\d+\.\d+\.\d+-[0-9A-Za-z.-]+$/.test(evidence.prereleaseVersion ?? '')) {
+  throw new Error('Evidence prereleaseVersion must be exact');
+}
+if (evidence.prereleaseVersion.split('-')[0] !== stableVersion) {
+  throw new Error('Evidence prerelease and stable versions must share a base version');
+}
+if (evidence.publicRepository !== 'https://github.com/felan-ai/felan') {
+  throw new Error('Evidence public repository is invalid');
+}
+if (!/^[0-9a-f]{40}$/.test(evidence.publicCommit ?? '')) throw new Error('Evidence publicCommit is invalid');
+if (evidence.publicRef !== `refs/tags/v${evidence.prereleaseVersion}`) {
+  throw new Error('Evidence publicRef does not match prereleaseVersion');
+}
+if (evidence.workflow !== '.github/workflows/release.yml') throw new Error('Evidence workflow is invalid');
+if (!/^\d+$/.test(String(evidence.privateCandidate?.trustedRunId ?? ''))) {
+  throw new Error('Evidence trusted candidate run is invalid');
+}
+if (!/^[0-9a-f]{40}$/.test(evidence.privateCandidate?.privateCommit ?? '')) {
+  throw new Error('Evidence private candidate commit is invalid');
+}
+if (!/^sha256:[0-9a-f]{64}$/.test(evidence.privateCandidate?.recordDigest ?? '')) {
+  throw new Error('Evidence candidate record digest is invalid');
+}
+
+const evidenceNames = Object.keys(evidence.packages ?? {}).sort();
+if (evidenceNames.join('\n') !== [...packageNames].sort().join('\n')) {
+  throw new Error('Evidence package set does not match the fixed public package set');
+}
+
+for (const packageName of packageNames) {
+  const expected = evidence.packages[packageName];
+  if (expected.version !== evidence.prereleaseVersion || !/^sha512-/.test(expected.integrity ?? '')) {
+    throw new Error(`${packageName} evidence version or integrity is invalid`);
+  }
+  const metadataResponse = await fetch(
+    `https://registry.npmjs.org/${encodeURIComponent(packageName)}/${evidence.prereleaseVersion}`,
+  );
+  if (!metadataResponse.ok) throw new Error(`Unable to resolve ${packageName} from npmjs`);
+  const metadata = await metadataResponse.json();
+  if (metadata.dist?.integrity !== expected.integrity || !metadata.dist?.attestations?.url) {
+    throw new Error(`${packageName} npm integrity or provenance differs from evidence`);
+  }
+  const attestationResponse = await fetch(metadata.dist.attestations.url);
+  if (!attestationResponse.ok) throw new Error(`Unable to fetch ${packageName} provenance`);
+  const attestations = await attestationResponse.json();
+  const provenance = attestations.attestations?.find(
+    (entry) => entry.predicateType === 'https://slsa.dev/provenance/v1',
+  );
+  const payload = provenance?.bundle?.dsseEnvelope?.payload;
+  if (!payload) throw new Error(`${packageName} has no SLSA provenance payload`);
+  const statement = JSON.parse(Buffer.from(payload, 'base64').toString('utf8'));
+  const workflow = statement.predicate?.buildDefinition?.externalParameters?.workflow;
+  const dependency = statement.predicate?.buildDefinition?.resolvedDependencies?.find(
+    (entry) => entry.uri === `git+https://github.com/felan-ai/felan@${evidence.publicRef}`,
+  );
+  if (
+    workflow?.repository !== evidence.publicRepository
+    || workflow?.path !== evidence.workflow
+    || workflow?.ref !== evidence.publicRef
+    || dependency?.digest?.gitCommit !== evidence.publicCommit
+  ) {
+    throw new Error(`${packageName} provenance differs from stable candidate evidence`);
+  }
+}
+
+console.log(`Stable evidence validates ${packageNames.length} packages from ${evidence.publicRef}`);

--- a/scripts/check-third-party-licenses.mjs
+++ b/scripts/check-third-party-licenses.mjs
@@ -1,0 +1,56 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const root = resolve(import.meta.dirname, '..');
+const result = spawnSync('pnpm', ['licenses', 'list', '--prod', '--json'], {
+  cwd: root,
+  encoding: 'utf8',
+});
+if (result.status !== 0) {
+  process.stderr.write(result.stderr);
+  process.exit(result.status ?? 1);
+}
+
+const inventory = JSON.parse(result.stdout);
+const allowedLicenses = new Set([
+  '0BSD',
+  'Apache-2.0',
+  'BSD-3-Clause',
+  'BlueOak-1.0.0',
+  'ISC',
+  'MIT',
+]);
+const errors = [];
+const packages = [];
+
+for (const [license, entries] of Object.entries(inventory)) {
+  if (!allowedLicenses.has(license)) errors.push(`Production dependency license requires review: ${license}`);
+  for (const entry of entries) {
+    for (const version of entry.versions ?? []) packages.push(`${entry.name}@${version}`);
+    if (entry.name.startsWith('@felan-cloud/')) {
+      errors.push(`Public production closure contains private package ${entry.name}`);
+    }
+  }
+}
+
+for (const required of [
+  '@earendil-works/pi-agent-core@0.82.1',
+  '@earendil-works/pi-ai@0.82.1',
+  '@earendil-works/pi-coding-agent@0.82.1',
+  '@earendil-works/pi-tui@0.82.1',
+  'typebox@1.1.38',
+]) {
+  if (!packages.includes(required)) errors.push(`Production license inventory is missing ${required}`);
+}
+
+const notice = readFileSync(resolve(root, 'NOTICE'), 'utf8');
+for (const requiredNotice of ['Pi 0.82.1', 'TypeBox 1.1.38']) {
+  if (!notice.includes(requiredNotice)) errors.push(`NOTICE is missing ${requiredNotice}`);
+}
+
+if (errors.length > 0) {
+  for (const error of errors) console.error(error);
+  process.exit(1);
+}
+console.log(`Validated ${packages.length} permissively licensed production package versions`);


### PR DESCRIPTION
## Summary
- require every release tag to point into `main` history
- audit the full production dependency license inventory
- gate future stable publication on committed trusted-candidate evidence, clean npm audit, and CLI/TUI co-install
- preserve alpha.3 package versions and runtime behavior

## Verification
- `pnpm verify`
- `pnpm check:licenses`
- stable-evidence fixture against live alpha.3 npm provenance
- actionlint

No tag or npm publication is part of this PR.