### PR TITLE
feat(tui): add felan update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,14 @@ Connect a provider inside the TUI with `/login`, then start working:
 felan "inspect this project and explain how to run its tests"
 felan --continue
 felan --diagnostics
+felan update
 ```
 
-The local CLI is interactive. An initial message starts the TUI; it is not a
-separate print or one-shot mode. See [Getting started](docs/getting-started.md)
-for first-run setup and [Local CLI](docs/user-guide/local-cli.md) for all
-accepted flags and local state.
+Initial messages start the interactive TUI; they are not separate print or
+one-shot modes. A verified global npm installation also supports the finite
+`felan update` command. See [Getting started](docs/getting-started.md) for
+first-run setup and [Local CLI](docs/user-guide/local-cli.md) for all accepted
+commands, flags, and local state.
 
 ## One agent, two hosts
 

--- a/apps/tui/README.md
+++ b/apps/tui/README.md
@@ -41,13 +41,22 @@ felan [options] [message]
 
 -c, --continue     Continue the most recent session for this directory
 --diagnostics      Print runtime versions and configuration mode
+update             Update a global npm installation of Felan
 -h, --help         Show help
 -v, --version      Print the Felan version
 --verbose          Show verbose startup details
 ```
 
-The public binary launches the interactive TUI. Internal headless modes used
-by subagents and extension adapters are not public CLI entry points.
+Run `felan update` to check the stable npm release. It updates only a verified
+global npm installation, reports when the installation is current, and tells
+you to restart after a successful update. `npx`, local/source, and other
+package-manager installations are not changed; update those with the command
+that installed them.
+
+Invocations that start or continue an agent session launch the interactive TUI.
+`felan update` and informational flags exit without starting a session. Internal
+headless modes used by subagents and extension adapters are not public CLI entry
+points.
 
 `felan --diagnostics` reports Felan, Agent Core, Pi, and Node.js versions plus
 runtime and credential modes.

--- a/apps/tui/package.json
+++ b/apps/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felan-ai/felan",
-  "version": "0.12.11",
+  "version": "0.13.0",
   "description": "Local Felan terminal agent",
   "license": "MIT",
   "type": "module",

--- a/apps/tui/src/cli-main.ts
+++ b/apps/tui/src/cli-main.ts
@@ -1,12 +1,12 @@
-import { AGENT_CORE_VERSION } from '@felan-ai/agent-core';
-import { VERSION as PI_VERSION } from '@earendil-works/pi-coding-agent';
-import { runLocalFelan, type RunLocalFelanOptions } from './application.js';
+import type { RunLocalFelanOptions } from './application.js';
+import { runFelanUpdate } from './update.js';
 import { FELAN_VERSION } from './version.js';
 
 export interface CliDependencies {
   readonly writeOutput?: (line: string) => void;
   readonly writeError?: (line: string) => void;
   readonly launch?: (options: RunLocalFelanOptions) => Promise<void>;
+  readonly update?: () => Promise<number>;
 }
 
 const help = `Usage: felan [options] [message]
@@ -14,6 +14,7 @@ const help = `Usage: felan [options] [message]
 Options:
   -c, --continue     Continue the most recent session for this directory
   --diagnostics      Print local runtime versions and configuration mode
+  update             Update a global npm installation of Felan
   -h, --help         Show this help
   -v, --version      Print the Felan version
   --verbose          Show verbose startup details`;
@@ -21,7 +22,14 @@ Options:
 export async function runCli(args: readonly string[], dependencies: CliDependencies = {}): Promise<number> {
   const writeOutput = dependencies.writeOutput ?? ((line) => console.log(line));
   const writeError = dependencies.writeError ?? ((line) => console.error(line));
-  const launch = dependencies.launch ?? runLocalFelan;
+  if (args[0] === 'update') {
+    if (args.length !== 1) {
+      writeError('Usage: felan update');
+      return 1;
+    }
+    return dependencies.update?.() ?? runFelanUpdate({ writeOutput, writeError });
+  }
+
   let continueRecent = false;
   let verbose = false;
   const messageParts: string[] = [];
@@ -45,6 +53,10 @@ export async function runCli(args: readonly string[], dependencies: CliDependenc
       writeOutput(FELAN_VERSION);
       return 0;
     } else if (argument === '--diagnostics') {
+      const [{ AGENT_CORE_VERSION }, { VERSION: PI_VERSION }] = await Promise.all([
+        import('@felan-ai/agent-core'),
+        import('@earendil-works/pi-coding-agent'),
+      ]);
       writeOutput(`Felan version: ${FELAN_VERSION}`);
       writeOutput(`Agent Core version: ${AGENT_CORE_VERSION}`);
       writeOutput(`Pi version: ${PI_VERSION}`);
@@ -60,6 +72,10 @@ export async function runCli(args: readonly string[], dependencies: CliDependenc
     }
   }
 
+  const launch = dependencies.launch ?? (async (options: RunLocalFelanOptions) => {
+    const { runLocalFelan } = await import('./application.js');
+    await runLocalFelan(options);
+  });
   await launch({
     continueRecent,
     verbose,

--- a/apps/tui/src/update.ts
+++ b/apps/tui/src/update.ts
@@ -1,0 +1,193 @@
+import { execFile } from 'node:child_process';
+import { existsSync, lstatSync, readFileSync, realpathSync } from 'node:fs';
+import { basename, delimiter, dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { FELAN_VERSION } from './version.js';
+
+const PACKAGE_NAME = '@felan-ai/felan';
+const PACKAGE_DIRECTORY = ['@felan-ai', 'felan'] as const;
+
+export interface NpmResult {
+  readonly status: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+export interface RunFelanUpdateOptions {
+  readonly packageDirectory?: string;
+  readonly currentVersion?: string;
+  readonly runNpm?: (args: readonly string[], cwd: string) => Promise<NpmResult>;
+  readonly writeOutput?: (line: string) => void;
+  readonly writeError?: (line: string) => void;
+}
+
+export async function runFelanUpdate(options: RunFelanUpdateOptions = {}): Promise<number> {
+  const writeOutput = options.writeOutput ?? ((line) => console.log(line));
+  const writeError = options.writeError ?? ((line) => console.error(line));
+  const packageDirectory = options.packageDirectory ?? dirname(dirname(fileURLToPath(import.meta.url)));
+  const currentVersion = options.currentVersion ?? FELAN_VERSION;
+  const runNpm = options.runNpm ?? runNpmCommand;
+
+  const globalRootResult = await runNpm(['root', '--global'], packageDirectory);
+  if (globalRootResult.status !== 0) {
+    writeError(`Could not find npm's global installation: ${commandError(globalRootResult)}`);
+    return 1;
+  }
+
+  const globalRoot = globalRootResult.stdout.trim();
+  const expectedPackageDirectory = join(globalRoot, ...PACKAGE_DIRECTORY);
+  if (!globalRoot || !samePath(packageDirectory, expectedPackageDirectory) || isSymbolicLink(expectedPackageDirectory)) {
+    writeError(
+      'Felan update only supports a verified global npm installation. '
+        + 'Run `npm install --global @felan-ai/felan` to update this installation manually.',
+    );
+    return 1;
+  }
+
+  const packageManifest = readPackageManifest(packageDirectory);
+  if (!packageManifest || packageManifest.name !== PACKAGE_NAME || packageManifest.version !== currentVersion) {
+    writeError('The running Felan package could not be verified. Update it manually with npm.');
+    return 1;
+  }
+
+  const latestResult = await runNpm(['view', `${PACKAGE_NAME}@latest`, 'version'], packageDirectory);
+  if (latestResult.status !== 0) {
+    writeError(`Could not check for a newer Felan release: ${commandError(latestResult)}`);
+    return 1;
+  }
+
+  const latestVersion = latestResult.stdout.trim();
+  if (!isStableVersion(latestVersion) || !isStableVersion(currentVersion)) {
+    writeError('npm returned an invalid stable Felan version. Update Felan manually.');
+    return 1;
+  }
+
+  const comparison = compareVersions(latestVersion, currentVersion);
+  if (comparison <= 0) {
+    writeOutput(`Felan ${currentVersion} is already up to date.`);
+    return 0;
+  }
+
+  const installResult = await runNpm(
+    ['install', '--global', `${PACKAGE_NAME}@${latestVersion}`],
+    packageDirectory,
+  );
+  if (installResult.status !== 0) {
+    writeError(`Felan update failed: ${commandError(installResult)}`);
+    return 1;
+  }
+
+  const installedManifest = readPackageManifest(packageDirectory);
+  if (installedManifest?.name !== PACKAGE_NAME || installedManifest.version !== latestVersion) {
+    writeError(`Felan update could not verify version ${latestVersion}. Update Felan manually.`);
+    return 1;
+  }
+
+  writeOutput(`Updated Felan from ${currentVersion} to ${latestVersion}. Restart Felan to use the new version.`);
+  return 0;
+}
+
+async function runNpmCommand(args: readonly string[], cwd: string): Promise<NpmResult> {
+  const npmCommand = resolveNpmCommand();
+  if (!npmCommand) {
+    return { status: 1, stdout: '', stderr: 'npm was not found' };
+  }
+
+  return new Promise((resolveResult) => {
+    execFile(npmCommand.command, [...npmCommand.arguments, ...args], {
+      cwd,
+      encoding: 'utf8',
+      windowsHide: true,
+    }, (error, stdout, stderr) => {
+      resolveResult({
+        status: error ? (typeof error.code === 'number' ? error.code : 1) : 0,
+        stdout,
+        stderr,
+      });
+    });
+  });
+}
+
+interface NpmCommand {
+  readonly command: string;
+  readonly arguments: readonly string[];
+}
+
+function resolveNpmCommand(): NpmCommand | undefined {
+  const npmCliCandidates = [
+    join(dirname(process.execPath), 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+    join(dirname(process.execPath), '..', 'lib', 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+    join(dirname(process.execPath), '..', 'share', 'nodejs', 'npm', 'bin', 'npm-cli.js'),
+  ];
+  for (const candidate of npmCliCandidates) {
+    if (candidate && basename(candidate).toLowerCase() === 'npm-cli.js' && existsSync(candidate)) {
+      return { command: process.execPath, arguments: [candidate] };
+    }
+  }
+
+  for (const directory of (process.env.PATH ?? '').split(delimiter)) {
+    if (!directory || directory.toLowerCase().includes('node_modules')) continue;
+    const executable = join(directory, process.platform === 'win32' ? 'npm.cmd' : 'npm');
+    if (!existsSync(executable)) continue;
+    if (process.platform === 'win32') {
+      const adjacentCli = join(directory, 'node_modules', 'npm', 'bin', 'npm-cli.js');
+      if (existsSync(adjacentCli)) return { command: process.execPath, arguments: [adjacentCli] };
+      continue;
+    }
+    return { command: executable, arguments: [] };
+  }
+  return undefined;
+}
+
+function readPackageManifest(packageDirectory: string): { name?: unknown; version?: unknown } | undefined {
+  try {
+    return JSON.parse(readFileSync(join(packageDirectory, 'package.json'), 'utf8')) as {
+      name?: unknown;
+      version?: unknown;
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function isSymbolicLink(path: string): boolean {
+  try {
+    return lstatSync(path).isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+function samePath(left: string, right: string): boolean {
+  const canonicalLeft = canonicalPath(left);
+  const canonicalRight = canonicalPath(right);
+  const normalizedLeft = process.platform === 'win32' ? canonicalLeft.toLowerCase() : canonicalLeft;
+  const normalizedRight = process.platform === 'win32' ? canonicalRight.toLowerCase() : canonicalRight;
+  return normalizedLeft === normalizedRight;
+}
+
+function canonicalPath(path: string): string {
+  const resolved = resolve(path);
+  try {
+    return realpathSync(resolved);
+  } catch {
+    return resolved;
+  }
+}
+
+function isStableVersion(version: string): boolean {
+  return /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/u.test(version);
+}
+
+function compareVersions(left: string, right: string): number {
+  const leftParts = left.split('.').map(Number);
+  const rightParts = right.split('.').map(Number);
+  for (let index = 0; index < leftParts.length; index += 1) {
+    if (leftParts[index] !== rightParts[index]) return leftParts[index]! > rightParts[index]! ? 1 : -1;
+  }
+  return 0;
+}
+
+function commandError(result: NpmResult): string {
+  return result.stderr.trim() || result.stdout.trim() || `npm exited with status ${result.status}`;
+}

--- a/apps/tui/test/cli.test.ts
+++ b/apps/tui/test/cli.test.ts
@@ -4,6 +4,70 @@ import { runCli } from '../src/cli-main.js';
 import { FELAN_VERSION } from '../src/version.js';
 
 describe('felan CLI', () => {
+  it('runs update without starting the interactive application', async () => {
+    let launched = false;
+    let updated = false;
+
+    const exitCode = await runCli(['update'], {
+      update: async () => {
+        updated = true;
+        return 7;
+      },
+      launch: async () => {
+        launched = true;
+      },
+    });
+
+    expect(exitCode).toBe(7);
+    expect(updated).toBe(true);
+    expect(launched).toBe(false);
+  });
+
+  it('rejects extra update arguments without starting the interactive application', async () => {
+    const errors: string[] = [];
+    let launched = false;
+    let updated = false;
+
+    const exitCode = await runCli(['update', '--help'], {
+      writeError: (line) => errors.push(line),
+      update: async () => {
+        updated = true;
+        return 0;
+      },
+      launch: async () => {
+        launched = true;
+      },
+    });
+
+    expect(exitCode).toBe(1);
+    expect(errors).toEqual(['Usage: felan update']);
+    expect(updated).toBe(false);
+    expect(launched).toBe(false);
+  });
+
+  it('keeps -- update as an initial interactive message', async () => {
+    const launches: unknown[] = [];
+    let updated = false;
+
+    const exitCode = await runCli(['--', 'update'], {
+      update: async () => {
+        updated = true;
+        return 0;
+      },
+      launch: async (options) => {
+        launches.push(options);
+      },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(updated).toBe(false);
+    expect(launches).toEqual([{
+      continueRecent: false,
+      verbose: false,
+      initialMessage: 'update',
+    }]);
+  });
+
   it('reports Felan and Agent Core versions in diagnostics', async () => {
     const output: string[] = [];
 

--- a/apps/tui/test/update.test.ts
+++ b/apps/tui/test/update.test.ts
@@ -1,0 +1,206 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { runFelanUpdate, type NpmResult } from '../src/update.js';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+});
+
+describe('Felan update', () => {
+  it('reports an already-current global npm installation without installing', async () => {
+    const fixture = await packageFixture('0.12.11');
+    const calls: string[][] = [];
+    const output: string[] = [];
+
+    const exitCode = await runFelanUpdate({
+      packageDirectory: fixture.packageDirectory,
+      currentVersion: '0.12.11',
+      runNpm: npmRunner(fixture.globalRoot, calls, '0.12.11'),
+      writeOutput: (line) => output.push(line),
+    });
+
+    expect(exitCode).toBe(0);
+    expect(calls).toEqual([
+      ['root', '--global'],
+      ['view', '@felan-ai/felan@latest', 'version'],
+    ]);
+    expect(output).toEqual(['Felan 0.12.11 is already up to date.']);
+  });
+
+  it('installs the exact newer stable version and verifies the package afterward', async () => {
+    const fixture = await packageFixture('0.12.11');
+    const calls: string[][] = [];
+    const output: string[] = [];
+
+    const exitCode = await runFelanUpdate({
+      packageDirectory: fixture.packageDirectory,
+      currentVersion: '0.12.11',
+      runNpm: npmRunner(fixture.globalRoot, calls, '0.12.12', true),
+      writeOutput: (line) => output.push(line),
+    });
+
+    expect(exitCode).toBe(0);
+    expect(calls).toEqual([
+      ['root', '--global'],
+      ['view', '@felan-ai/felan@latest', 'version'],
+      ['install', '--global', '@felan-ai/felan@0.12.12'],
+    ]);
+    expect(output).toEqual([
+      'Updated Felan from 0.12.11 to 0.12.12. Restart Felan to use the new version.',
+    ]);
+  });
+
+  it('does not downgrade when npm latest is older', async () => {
+    const fixture = await packageFixture('0.12.11');
+    const calls: string[][] = [];
+    const output: string[] = [];
+
+    const exitCode = await runFelanUpdate({
+      packageDirectory: fixture.packageDirectory,
+      currentVersion: '0.12.11',
+      runNpm: npmRunner(fixture.globalRoot, calls, '0.12.10'),
+      writeOutput: (line) => output.push(line),
+    });
+
+    expect(exitCode).toBe(0);
+    expect(calls).toHaveLength(2);
+    expect(output).toEqual(['Felan 0.12.11 is already up to date.']);
+  });
+
+  it('rejects an installation that is not the global npm package before checking the registry', async () => {
+    const fixture = await packageFixture('0.12.11');
+    const localDirectory = await temporaryDirectory('felan-local-');
+    const calls: string[][] = [];
+    const errors: string[] = [];
+
+    const exitCode = await runFelanUpdate({
+      packageDirectory: localDirectory,
+      currentVersion: '0.12.11',
+      runNpm: npmRunner(fixture.globalRoot, calls, '0.12.12'),
+      writeError: (line) => errors.push(line),
+    });
+
+    expect(exitCode).toBe(1);
+    expect(calls).toEqual([['root', '--global']]);
+    expect(errors[0]).toContain('only supports a verified global npm installation');
+  });
+
+  it('rejects prerelease or malformed registry versions', async () => {
+    const fixture = await packageFixture('0.12.11');
+    const calls: string[][] = [];
+    const errors: string[] = [];
+
+    const exitCode = await runFelanUpdate({
+      packageDirectory: fixture.packageDirectory,
+      currentVersion: '0.12.11',
+      runNpm: npmRunner(fixture.globalRoot, calls, '0.13.0-next.1'),
+      writeError: (line) => errors.push(line),
+    });
+
+    expect(exitCode).toBe(1);
+    expect(calls).toHaveLength(2);
+    expect(errors).toEqual(['npm returned an invalid stable Felan version. Update Felan manually.']);
+  });
+
+  it('returns a failure when npm cannot resolve its global root or latest release', async () => {
+    const fixture = await packageFixture('0.12.11');
+    const errors: string[] = [];
+
+    await expect(runFelanUpdate({
+      packageDirectory: fixture.packageDirectory,
+      runNpm: async () => npmFailure('permission denied'),
+      writeError: (line) => errors.push(line),
+    })).resolves.toBe(1);
+    expect(errors[0]).toContain('Could not find npm\'s global installation: permission denied');
+
+    errors.length = 0;
+    await expect(runFelanUpdate({
+      packageDirectory: fixture.packageDirectory,
+      currentVersion: '0.12.11',
+      runNpm: async (args) => args[0] === 'root'
+        ? npmSuccess(fixture.globalRoot)
+        : npmFailure('registry unavailable'),
+      writeError: (line) => errors.push(line),
+    })).resolves.toBe(1);
+    expect(errors).toEqual(['Could not check for a newer Felan release: registry unavailable']);
+  });
+
+  it('returns a failure when installation or post-install verification fails', async () => {
+    const fixture = await packageFixture('0.12.11');
+    const errors: string[] = [];
+
+    await expect(runFelanUpdate({
+      packageDirectory: fixture.packageDirectory,
+      currentVersion: '0.12.11',
+      runNpm: async (args) => args[0] === 'root'
+        ? npmSuccess(fixture.globalRoot)
+        : args[0] === 'view'
+          ? npmSuccess('0.12.12')
+          : npmFailure('install failed'),
+      writeError: (line) => errors.push(line),
+    })).resolves.toBe(1);
+    expect(errors).toEqual(['Felan update failed: install failed']);
+
+    errors.length = 0;
+    await expect(runFelanUpdate({
+      packageDirectory: fixture.packageDirectory,
+      currentVersion: '0.12.11',
+      runNpm: async (args) => args[0] === 'root'
+        ? npmSuccess(fixture.globalRoot)
+        : npmSuccess(args[0] === 'view' ? '0.12.12' : ''),
+      writeError: (line) => errors.push(line),
+    })).resolves.toBe(1);
+    expect(errors).toEqual(['Felan update could not verify version 0.12.12. Update Felan manually.']);
+  });
+});
+
+interface PackageFixture {
+  readonly globalRoot: string;
+  readonly packageDirectory: string;
+}
+
+async function packageFixture(version: string, name = '@felan-ai/felan'): Promise<PackageFixture> {
+  const globalRoot = await temporaryDirectory('felan-global-');
+  const packageDirectory = join(globalRoot, '@felan-ai', 'felan');
+  await mkdir(packageDirectory, { recursive: true });
+  await writeFile(join(packageDirectory, 'package.json'), JSON.stringify({ name, version }));
+  return { globalRoot, packageDirectory };
+}
+
+function npmRunner(
+  globalRoot: string,
+  calls: string[][],
+  latestVersion: string,
+  updateManifest = false,
+): (args: readonly string[], cwd: string) => Promise<NpmResult> {
+  return async (args) => {
+    calls.push([...args]);
+    if (args[0] === 'root') return npmSuccess(globalRoot);
+    if (args[0] === 'view') return npmSuccess(latestVersion);
+    if (args[0] === 'install' && updateManifest) {
+      await writeFile(join(globalRoot, '@felan-ai', 'felan', 'package.json'), JSON.stringify({
+        name: '@felan-ai/felan',
+        version: latestVersion,
+      }));
+    }
+    return npmSuccess('');
+  };
+}
+
+function npmSuccess(stdout: string): NpmResult {
+  return { status: 0, stdout, stderr: '' };
+}
+
+function npmFailure(stderr: string): NpmResult {
+  return { status: 1, stdout: '', stderr };
+}
+
+async function temporaryDirectory(prefix: string): Promise<string> {
+  const path = await mkdtemp(join(tmpdir(), prefix));
+  temporaryDirectories.push(path);
+  return path;
+}

--- a/docs/user-guide/local-cli.md
+++ b/docs/user-guide/local-cli.md
@@ -11,6 +11,7 @@ felan [options] [message]
 
 -c, --continue     Continue the most recent session for this directory
 --diagnostics      Print runtime versions and configuration mode
+update             Update a global npm installation of Felan
 -h, --help         Show help
 -v, --version      Print the Felan version
 --verbose          Show verbose startup details
@@ -19,9 +20,29 @@ felan [options] [message]
 Use `--` before an initial message that begins with a dash. Unknown options are
 rejected before the TUI starts.
 
-The public CLI always launches the interactive terminal application. Internal
-headless modes used by subagents and extension adapters are not public CLI
-entry points.
+### Update Felan
+
+Update a globally installed Felan CLI with:
+
+```sh
+felan update
+```
+
+The command checks npm's stable `latest` release without starting the TUI. If
+the global installation is current, it reports that no update is needed. If a
+newer release is available, it installs that exact `@felan-ai/felan` version
+and tells you to restart Felan. Registry, installation, and verification
+failures return a non-zero exit status and do not claim success.
+
+Self-update is limited to the verified global npm installation that provides
+the running `felan` command. `npx`, local/source, pnpm, yarn, and bun
+installations are not changed; update those with their normal package-manager
+command instead. To send `update` as an initial prompt, use `felan -- update`.
+
+Invocations that start or continue an agent session launch the interactive TUI.
+`felan update` and informational flags exit without starting a session. Internal
+headless modes used by subagents and extension adapters are not public CLI entry
+points.
 
 ## Diagnostics
 

--- a/scripts/test-packed-bin.mjs
+++ b/scripts/test-packed-bin.mjs
@@ -20,9 +20,17 @@ const cleanHome = join(installDir, 'home');
 const cacheDir = join(installDir, 'npm-cache');
 const workspace = join(installDir, 'workspace');
 const agentDir = join(cleanHome, '.felan');
-const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const npm = process.platform === 'win32' ? process.execPath : 'npm';
+const npmArguments = process.platform === 'win32'
+  ? [join(dirname(process.execPath), 'node_modules', 'npm', 'bin', 'npm-cli.js')]
+  : [];
 const binDirectory = join(installDir, 'node_modules', '.bin');
-const felan = join(binDirectory, process.platform === 'win32' ? 'felan.cmd' : 'felan');
+const felan = process.platform === 'win32'
+  ? process.execPath
+  : join(binDirectory, 'felan');
+const felanArguments = process.platform === 'win32'
+  ? [join(installDir, 'node_modules', '@felan-ai', 'felan', 'dist', 'cli.js')]
+  : [];
 const sourcePackages = packagePaths.map((packagePath) => JSON.parse(
   readFileSync(resolve(root, packagePath, 'package.json'), 'utf8'),
 ));
@@ -60,7 +68,7 @@ try {
     throw new Error(`Expected ${sourcePackages.length} packed artifacts, found ${tarballs.length}`);
   }
 
-  run(npm, [
+  runNpm([
     'install',
     '--ignore-scripts',
     '--no-fund',
@@ -336,9 +344,12 @@ try {
         agentStorageRoot: ptyAgentStorage,
       });
       if (!ptyRuntime.terminals) throw new Error('Packed HostAgentRuntime has no PTY capability');
-      const ptyScript = "process.stdout.write('packed-pty:' + process.stdout.isTTY)";
+      await fs.writeFile(
+        process.env.PACKED_SMOKE_WORKSPACE + '/packed-pty.mjs',
+        "process.stdout.write('packed-pty:' + process.stdout.isTTY)",
+      );
       const terminal = await ptyRuntime.terminals.startShell(
-        JSON.stringify(process.execPath) + ' -e ' + JSON.stringify(ptyScript),
+        'node packed-pty.mjs',
         { login: false },
       );
       let terminalOffset = 0;
@@ -372,10 +383,11 @@ try {
         throw new Error('Packed runtime capability order is incorrect');
       }
       await runtime.dispose();
+      process.exit(0);
     `,
   ], cleanEnvironment);
 
-  const diagnostics = run(felan, ['--diagnostics'], cleanEnvironment);
+  const diagnostics = runFelan(['--diagnostics'], cleanEnvironment);
   for (const expected of [
     `Felan version: ${felanVersion}`,
     `Agent Core version: ${agentCoreVersion}`,
@@ -387,11 +399,15 @@ try {
       throw new Error(`Packed felan --diagnostics output is missing ${JSON.stringify(expected)}`);
     }
   }
-  const help = run(felan, ['--help'], cleanEnvironment);
-  if (!help.stdout.includes('Usage: felan [options] [message]')) {
+  const help = runFelan(['--help'], cleanEnvironment);
+  if (!help.stdout.includes('Usage: felan [options] [message]') || !help.stdout.includes('update')) {
     throw new Error('Packed felan --help did not start the local TUI CLI');
   }
-  const versionResult = run(felan, ['--version'], cleanEnvironment);
+  const update = runFelanAllowFailure(['update'], cleanEnvironment);
+  if (update.status === 0 || !update.stderr.includes('only supports a verified global npm installation')) {
+    throw new Error('Packed felan update did not reject the isolated non-global installation');
+  }
+  const versionResult = runFelan(['--version'], cleanEnvironment);
   if (versionResult.stdout.trim() !== felanVersion) {
     throw new Error(`Packed felan --version reported ${JSON.stringify(versionResult.stdout.trim())}`);
   }
@@ -401,7 +417,7 @@ try {
   }
 
   if (audit) {
-    run(npm, ['audit', '--audit-level=high', '--prefix', installDir], cleanEnvironment);
+    runNpm(['audit', '--audit-level=high', '--prefix', installDir], cleanEnvironment);
   }
 } finally {
   rmSync(installDir, { recursive: true, force: true });
@@ -549,9 +565,31 @@ function run(command, args, env = process.env) {
     env,
   });
   if (result.status !== 0) {
-    process.stderr.write(result.stdout);
-    process.stderr.write(result.stderr);
-    throw new Error(`${command} exited with status ${result.status ?? 'unknown'}`);
+    process.stderr.write(result.stdout ?? '');
+    process.stderr.write(result.stderr ?? '');
+    throw new Error(`${command} exited with status ${result.status ?? 'unknown'}${result.error ? `: ${result.error.message}` : ''}`);
   }
   return result;
+}
+
+function runFelan(args, env = process.env) {
+  return run(felan, [...felanArguments, ...args], env);
+}
+
+function runFelanAllowFailure(args, env = process.env) {
+  return runAllowFailure(felan, [...felanArguments, ...args], env);
+}
+
+function runAllowFailure(command, args, env = process.env) {
+  const result = spawnSync(command, args, {
+    cwd: installDir,
+    encoding: 'utf8',
+    env,
+  });
+  if (result.error) throw result.error;
+  return result;
+}
+
+function runNpm(args, env = process.env) {
+  return run(npm, [...npmArguments, ...args], env);
 }


### PR DESCRIPTION
## Summary

- reserve `felan update` as a finite CLI command while preserving `felan -- update` as an initial prompt
- update only a verified global npm installation to the exact stable `@felan-ai/felan` release, with no prerelease or downgrade behavior
- verify the installed manifest, provide restart guidance, and return actionable failures without loading the TUI
- document the command, bump the 0.x CLI release to `0.13.0`, and add focused plus packed-binary coverage

## Testing

- `pnpm --filter @felan-ai/felan exec vitest run test/cli.test.ts test/update.test.ts` (13 passed)
- `pnpm type-check`
- `pnpm exec tsc -p apps/tui/tsconfig.build.json`
- `pnpm check:proposed-version`
- `node scripts/test-packed-bin.mjs`

## Local verification notes

- The full TUI suite passed 182/183 tests locally; the remaining failure is the pre-existing `memory-coordinator.test.ts` memory artifact validation failure, unrelated to this diff.
- This Windows environment uses Node 24 rather than the repository-pinned Node 22.20.0. The existing license script cannot spawn the pnpm shim here; the dependency graph is unchanged by this PR.

Linear: [BUG-390](https://linear.app/bugzyai/issue/BUG-390/add-a-first-party-felan-update-command)
