### PR TITLE
feat(tui): notify when Felan updates are available

### DIFF
--- a/apps/tui/README.md
+++ b/apps/tui/README.md
@@ -53,6 +53,13 @@ you to restart after a successful update. `npx`, local/source, and other
 package-manager installations are not changed; update those with the command
 that installed them.
 
+Interactive startup also checks npm once, asynchronously, for a newer stable
+release. If one is available, Felan tells you to exit all Felan sessions and
+run `felan update` for a global npm installation, or use the package manager
+that launched Felan. Offline, failed, and malformed responses stay silent, and
+Felan never installs an update automatically. Set
+`FELAN_SKIP_VERSION_CHECK=1` to disable this startup request.
+
 Invocations that start or continue an agent session launch the interactive TUI.
 `felan update` and informational flags exit without starting a session. Internal
 headless modes used by subagents and extension adapters are not public CLI entry

--- a/apps/tui/package.json
+++ b/apps/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felan-ai/felan",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Local Felan terminal agent",
   "license": "MIT",
   "type": "module",

--- a/apps/tui/src/application.ts
+++ b/apps/tui/src/application.ts
@@ -6,6 +6,7 @@ import {
 } from './runtime.js';
 import { installFelanStartupHeader } from './startup-header.js';
 import { createToolActivityRuntimeView } from './tool-activity/runtime-view.js';
+import { checkForFelanUpdate } from './update.js';
 
 export interface RunLocalFelanOptions extends CreateLocalFelanRuntimeOptions {
   readonly initialMessage?: string;
@@ -37,7 +38,28 @@ export async function runLocalFelan(options: RunLocalFelanOptions = {}): Promise
         'summary.md',
       ),
     });
-    await mode.run();
+    // Pi starts passive checks immediately after its idempotent initialization.
+    // Initialize first so Felan's check begins at the same lifecycle point.
+    await mode.init();
+    const updateCheckController = new AbortController();
+    let modeActive = true;
+    const updateNotification = checkForFelanUpdate({ signal: updateCheckController.signal })
+      .then((latestVersion) => {
+        if (modeActive && latestVersion) {
+          mode.showWarning(
+            `Felan ${latestVersion} is available. Exit all Felan sessions, then run felan update `
+              + '(global npm) or update with your package manager.',
+          );
+        }
+      })
+      .catch(() => {});
+    try {
+      await mode.run();
+    } finally {
+      modeActive = false;
+      updateCheckController.abort();
+      await updateNotification;
+    }
   } finally {
     try {
       await runtime.dispose();

--- a/apps/tui/src/update.ts
+++ b/apps/tui/src/update.ts
@@ -6,6 +6,8 @@ import { FELAN_VERSION } from './version.js';
 
 const PACKAGE_NAME = '@felan-ai/felan';
 const PACKAGE_DIRECTORY = ['@felan-ai', 'felan'] as const;
+const LATEST_RELEASE_URL = 'https://registry.npmjs.org/@felan-ai%2Ffelan/latest';
+const DEFAULT_VERSION_CHECK_TIMEOUT_MS = 10_000;
 
 export interface NpmResult {
   readonly status: number;
@@ -19,6 +21,45 @@ export interface RunFelanUpdateOptions {
   readonly runNpm?: (args: readonly string[], cwd: string) => Promise<NpmResult>;
   readonly writeOutput?: (line: string) => void;
   readonly writeError?: (line: string) => void;
+}
+
+export interface CheckForFelanUpdateOptions {
+  readonly currentVersion?: string;
+  readonly fetch?: typeof globalThis.fetch;
+  readonly signal?: AbortSignal;
+  readonly timeoutMs?: number;
+}
+
+export async function checkForFelanUpdate(
+  options: CheckForFelanUpdateOptions = {},
+): Promise<string | undefined> {
+  if (process.env.FELAN_SKIP_VERSION_CHECK || process.env.PI_OFFLINE) return undefined;
+
+  const currentVersion = options.currentVersion ?? FELAN_VERSION;
+  if (!isStableVersion(currentVersion)) return undefined;
+
+  try {
+    const timeoutSignal = AbortSignal.timeout(options.timeoutMs ?? DEFAULT_VERSION_CHECK_TIMEOUT_MS);
+    const signal = options.signal ? AbortSignal.any([options.signal, timeoutSignal]) : timeoutSignal;
+    const response = await (options.fetch ?? globalThis.fetch)(LATEST_RELEASE_URL, {
+      headers: {
+        accept: 'application/json',
+        'User-Agent': `felan/${currentVersion} (${process.platform}; node/${process.versions.node}; ${process.arch})`,
+      },
+      signal,
+    });
+    if (!response.ok) return undefined;
+
+    const data: unknown = await response.json();
+    if (!isRecord(data) || typeof data.version !== 'string') return undefined;
+    const latestVersion = data.version.trim();
+    if (!isStableVersion(latestVersion) || compareVersions(latestVersion, currentVersion) <= 0) {
+      return undefined;
+    }
+    return latestVersion;
+  } catch {
+    return undefined;
+  }
 }
 
 export async function runFelanUpdate(options: RunFelanUpdateOptions = {}): Promise<number> {
@@ -190,4 +231,8 @@ function compareVersions(left: string, right: string): number {
 
 function commandError(result: NpmResult): string {
   return result.stderr.trim() || result.stdout.trim() || `npm exited with status ${result.status}`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/apps/tui/test/application.test.ts
+++ b/apps/tui/test/application.test.ts
@@ -6,15 +6,21 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 const interactive = vi.hoisted(() => ({
   agentDirs: [] as Array<string | undefined>,
   constructorError: undefined as Error | undefined,
+  deferUpdateCheck: false,
   disposals: 0,
+  events: [] as string[],
   piTelemetry: [] as Array<string | undefined>,
   piVersionChecks: [] as Array<string | undefined>,
   headerAdapters: [] as boolean[],
+  initializations: 0,
+  latestUpdate: undefined as string | undefined,
   modeOptions: [] as unknown[],
   runError: undefined as Error | undefined,
   runs: 0,
   toolRenderShells: [] as Array<string | undefined>,
   toolNames: [] as string[],
+  updateCheckSignals: [] as AbortSignal[],
+  warnings: [] as string[],
 }));
 
 vi.mock('@earendil-works/pi-coding-agent', async (importOriginal) => {
@@ -40,8 +46,14 @@ vi.mock('@earendil-works/pi-coding-agent', async (importOriginal) => {
         if (interactive.constructorError) throw interactive.constructorError;
       }
 
+      async init() {
+        interactive.initializations += 1;
+        interactive.events.push('init');
+      }
+
       async run() {
         interactive.runs += 1;
+        interactive.events.push('run');
         interactive.headerAdapters.push(
           typeof Object.getOwnPropertyDescriptor(this, 'builtInHeader')?.get === 'function',
         );
@@ -49,6 +61,38 @@ vi.mock('@earendil-works/pi-coding-agent', async (importOriginal) => {
         interactive.toolNames = this.runtime.session.agent.state.tools.map((tool) => tool.name);
         if (interactive.runError) throw interactive.runError;
       }
+
+      showWarning(message: string) {
+        interactive.warnings.push(message);
+        interactive.events.push('warning');
+      }
+    },
+  };
+});
+
+vi.mock('../src/update.js', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../src/update.js')>();
+  return {
+    ...original,
+    checkForFelanUpdate: async (options?: { signal?: AbortSignal }) => {
+      interactive.events.push('check');
+      if (options?.signal) interactive.updateCheckSignals.push(options.signal);
+      if (interactive.deferUpdateCheck) {
+        return new Promise<string | undefined>((resolve) => {
+          const signal = options?.signal;
+          if (!signal) {
+            resolve(undefined);
+            return;
+          }
+          const handleAbort = () => {
+            interactive.events.push('check-abort');
+            resolve(undefined);
+          };
+          if (signal.aborted) handleAbort();
+          else signal.addEventListener('abort', handleAbort, { once: true });
+        });
+      }
+      return interactive.latestUpdate;
     },
   };
 });
@@ -60,15 +104,21 @@ const temporaryPaths: string[] = [];
 afterEach(async () => {
   interactive.agentDirs = [];
   interactive.constructorError = undefined;
+  interactive.deferUpdateCheck = false;
   interactive.disposals = 0;
+  interactive.events = [];
   interactive.piTelemetry = [];
   interactive.piVersionChecks = [];
   interactive.headerAdapters = [];
+  interactive.initializations = 0;
+  interactive.latestUpdate = undefined;
   interactive.modeOptions = [];
   interactive.runError = undefined;
   interactive.runs = 0;
   interactive.toolRenderShells = [];
   interactive.toolNames = [];
+  interactive.updateCheckSignals = [];
+  interactive.warnings = [];
   await Promise.all(temporaryPaths.splice(0).map((path) => rm(path, { force: true, recursive: true })));
 });
 
@@ -85,6 +135,7 @@ describe('interactive application', () => {
     await runLocalFelan({ cwd, agentDir });
 
     expect(interactive.runs).toBe(1);
+    expect(interactive.initializations).toBe(1);
     expect(interactive.agentDirs).toEqual([agentDir]);
     expect(interactive.piVersionChecks).toEqual(['1']);
     expect(interactive.piTelemetry).toEqual(['0']);
@@ -108,6 +159,38 @@ describe('interactive application', () => {
       'TaskGet',
     ]));
     expect(interactive.toolNames).not.toContain('spawn_agent');
+  });
+
+  it('checks for a Felan update after initialization and reports a newer release', async () => {
+    const root = await temporaryDirectory();
+    const cwd = join(root, 'workspace');
+    const agentDir = join(root, 'agent');
+    await mkdir(cwd, { recursive: true });
+    interactive.latestUpdate = '0.13.2';
+
+    await runLocalFelan({ cwd, agentDir });
+
+    expect(interactive.events).toEqual(['init', 'check', 'run', 'warning']);
+    expect(interactive.warnings).toEqual([
+      'Felan 0.13.2 is available. Exit all Felan sessions, then run felan update '
+        + '(global npm) or update with your package manager.',
+    ]);
+  });
+
+  it('cancels a pending update check before disposing the interactive runtime', async () => {
+    const root = await temporaryDirectory();
+    const cwd = join(root, 'workspace');
+    const agentDir = join(root, 'agent');
+    await mkdir(cwd, { recursive: true });
+    interactive.deferUpdateCheck = true;
+
+    await runLocalFelan({ cwd, agentDir });
+
+    expect(interactive.events).toEqual(['init', 'check', 'run', 'check-abort']);
+    expect(interactive.updateCheckSignals).toHaveLength(1);
+    expect(interactive.updateCheckSignals[0]?.aborted).toBe(true);
+    expect(interactive.warnings).toEqual([]);
+    expect(interactive.disposals).toBe(1);
   });
 
   it('disposes the runtime when InteractiveMode construction fails', async () => {

--- a/apps/tui/test/update.test.ts
+++ b/apps/tui/test/update.test.ts
@@ -1,13 +1,124 @@
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
-import { runFelanUpdate, type NpmResult } from '../src/update.js';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  checkForFelanUpdate,
+  runFelanUpdate,
+  type NpmResult,
+} from '../src/update.js';
 
 const temporaryDirectories: string[] = [];
+const previousFelanSkipVersionCheck = process.env.FELAN_SKIP_VERSION_CHECK;
+const previousPiOffline = process.env.PI_OFFLINE;
+
+beforeEach(() => {
+  delete process.env.FELAN_SKIP_VERSION_CHECK;
+  delete process.env.PI_OFFLINE;
+});
 
 afterEach(async () => {
+  if (previousFelanSkipVersionCheck === undefined) delete process.env.FELAN_SKIP_VERSION_CHECK;
+  else process.env.FELAN_SKIP_VERSION_CHECK = previousFelanSkipVersionCheck;
+  if (previousPiOffline === undefined) delete process.env.PI_OFFLINE;
+  else process.env.PI_OFFLINE = previousPiOffline;
   await Promise.all(temporaryDirectories.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+});
+
+describe('Felan update availability check', () => {
+  it('checks npm once with a bounded request and returns a newer stable release', async () => {
+    let requestedUrl: string | undefined;
+    let requestInit: RequestInit | undefined;
+
+    const latestVersion = await checkForFelanUpdate({
+      currentVersion: '0.13.0',
+      timeoutMs: 50,
+      fetch: async (input, init) => {
+        requestedUrl = String(input);
+        requestInit = init;
+        return jsonResponse({ version: '0.13.1' });
+      },
+    });
+
+    expect(latestVersion).toBe('0.13.1');
+    expect(requestedUrl).toBe('https://registry.npmjs.org/@felan-ai%2Ffelan/latest');
+    expect(new Headers(requestInit?.headers).get('accept')).toBe('application/json');
+    expect(new Headers(requestInit?.headers).get('user-agent')).toContain('felan/0.13.0');
+    expect(requestInit?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it.each(['0.13.0', '0.12.9', '0.13.1-next.1', 'not-a-version'])(
+    'ignores a non-newer stable release response: %s',
+    async (version) => {
+      await expect(checkForFelanUpdate({
+        currentVersion: '0.13.0',
+        fetch: async () => jsonResponse({ version }),
+      })).resolves.toBeUndefined();
+    },
+  );
+
+  it('silently ignores failed and malformed registry responses', async () => {
+    await expect(checkForFelanUpdate({
+      currentVersion: '0.13.0',
+      fetch: async () => new Response('', { status: 503 }),
+    })).resolves.toBeUndefined();
+    await expect(checkForFelanUpdate({
+      currentVersion: '0.13.0',
+      fetch: async () => new Response('{', { status: 200 }),
+    })).resolves.toBeUndefined();
+    await expect(checkForFelanUpdate({
+      currentVersion: '0.13.0',
+      fetch: async () => { throw new Error('offline'); },
+    })).resolves.toBeUndefined();
+  });
+
+  it('silently stops a request at the configured timeout', async () => {
+    await expect(checkForFelanUpdate({
+      currentVersion: '0.13.0',
+      timeoutMs: 5,
+      fetch: async (_input, init) => new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal;
+        if (!signal) throw new Error('missing abort signal');
+        signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+      }),
+    })).resolves.toBeUndefined();
+  });
+
+  it('honors caller cancellation', async () => {
+    const controller = new AbortController();
+    let requestSignal: AbortSignal | undefined;
+    const check = checkForFelanUpdate({
+      currentVersion: '0.13.0',
+      signal: controller.signal,
+      fetch: async (_input, init) => new Promise<Response>((_resolve, reject) => {
+        requestSignal = init?.signal ?? undefined;
+        if (!requestSignal) throw new Error('missing abort signal');
+        requestSignal.addEventListener('abort', () => reject(requestSignal?.reason), { once: true });
+      }),
+    });
+
+    controller.abort();
+
+    await expect(check).resolves.toBeUndefined();
+    expect(requestSignal?.aborted).toBe(true);
+  });
+
+  it.each(['PI_OFFLINE', 'FELAN_SKIP_VERSION_CHECK'] as const)(
+    'skips the request when %s is set',
+    async (environmentVariable) => {
+      process.env[environmentVariable] = '1';
+      let requested = false;
+
+      await expect(checkForFelanUpdate({
+        currentVersion: '0.13.0',
+        fetch: async () => {
+          requested = true;
+          return jsonResponse({ version: '0.13.1' });
+        },
+      })).resolves.toBeUndefined();
+      expect(requested).toBe(false);
+    },
+  );
 });
 
 describe('Felan update', () => {
@@ -197,6 +308,13 @@ function npmSuccess(stdout: string): NpmResult {
 
 function npmFailure(stderr: string): NpmResult {
   return { status: 1, stdout: '', stderr };
+}
+
+function jsonResponse(value: unknown): Response {
+  return new Response(JSON.stringify(value), {
+    headers: { 'Content-Type': 'application/json' },
+    status: 200,
+  });
 }
 
 async function temporaryDirectory(prefix: string): Promise<string> {

--- a/docs/user-guide/local-cli.md
+++ b/docs/user-guide/local-cli.md
@@ -34,6 +34,13 @@ newer release is available, it installs that exact `@felan-ai/felan` version
 and tells you to restart Felan. Registry, installation, and verification
 failures return a non-zero exit status and do not claim success.
 
+Interactive Felan checks npm once per launch, asynchronously, with a ten-second
+timeout and no retries. A newer stable release produces a notification to exit
+all Felan sessions and run `felan update` for global npm, or use the package
+manager that launched Felan. Offline, failed, and malformed responses stay
+silent. Startup checks never install updates. Set
+`FELAN_SKIP_VERSION_CHECK=1` to disable the request.
+
 Self-update is limited to the verified global npm installation that provides
 the running `felan` command. `npx`, local/source, pnpm, yarn, and bun
 installations are not changed; update those with their normal package-manager


### PR DESCRIPTION
## Summary

- check npm once per interactive launch for a newer stable Felan release, matching Pi's asynchronous 10-second/no-retry startup pattern
- notify without installing, with instructions for global npm and other package-manager installations
- cancel pending checks during TUI shutdown and keep offline, opted-out, failed, or malformed checks silent
- document `FELAN_SKIP_VERSION_CHECK` and bump `@felan-ai/felan` to `0.13.1`

## Testing

- `pnpm --filter @felan-ai/felan exec vitest run test/update.test.ts test/application.test.ts` (23 passed)
- `pnpm --filter @felan-ai/felan type-check`
- `pnpm type-check`
- `pnpm -r exec tsc -p tsconfig.build.json`
- `pnpm check:proposed-version`
- `node scripts/test-packed-bin.mjs`
- real npm endpoint checks for current and older injected versions

## Local verification note

The complete TUI run retains the pre-existing Windows-only `memory-coordinator.test.ts` invalid-artifact failure. A serial rerun passed the other 33 tests in the two initially failing files and reproduced only that unrelated baseline failure.

Follow-up to #9 and [BUG-390](https://linear.app/bugzyai/issue/BUG-390/add-a-first-party-felan-update-command).
