### PR TITLE
fix: support Background Bash on native Windows

### DIFF
--- a/apps/tui/package.json
+++ b/apps/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felan-ai/felan",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "description": "Local Felan terminal agent",
   "license": "MIT",
   "type": "module",

--- a/docs/reference/runtime-dependencies.md
+++ b/docs/reference/runtime-dependencies.md
@@ -29,7 +29,17 @@ portable detection, optional installation, and safe unavailable behavior;
 | MarkItDown document conversion | `markitdown` 0.1.7 | Read interception is bypassed; the extension can be disabled globally | Managed Python virtual environment |
 | RTK command rewriting | compatible `rtk` | Rewriting is bypassed; binary-independent output compaction remains active | Digest-verified official installer pinned to RTK 0.45.0 on Linux/macOS |
 | Browser automation and screenshots | `agent-browser` 0.31.1 | The browser tool is unavailable; the extension can be disabled | Integrity-verified native CLI package in Felan agent storage; Chrome is installed separately by an explicit agent-browser action |
-| Background Bash detached processes | POSIX shell plus `sh`, `nohup`, `ps`, `tr`, `kill`, `date`, `cat`, and `mv` | Background Bash tools remain inactive | No managed installer; use a compatible runtime |
+| Background Bash detached processes | POSIX shell plus `sh`, `nohup`, `ps`, `tr`, `kill`, `date`, `cat`, `mv`, and `sleep` | Background Bash tools remain inactive | No managed installer; use a compatible runtime |
+
+On native Windows, the ordinary `cmd.exe` shell is not a POSIX runtime. The
+host runtime therefore keeps `cmd.exe` as the default for ordinary shell calls
+but can select a same-host Git Bash executable for POSIX calls. It checks
+`FELAN_POSIX_SHELL`, executable `PATH` entries, and standard Git-for-Windows
+install locations. WSL is not selected automatically because its process and
+path namespace is separate from the native host. If no compatible Git Bash
+installation is available, Background Bash stays inactive and Felan does not
+attempt to install operating-system utilities. Git Bash process inspection
+uses its `ps -l` output when the GNU `ps -o` form is unavailable.
 
 Other process calls are not whole-extension startup dependencies. `git` in web
 repository extraction and the powerline is optional per operation; credential

--- a/packages/agent-core/README.md
+++ b/packages/agent-core/README.md
@@ -31,6 +31,14 @@ a time rather than materializing an unbounded recursive scan. `exec` and `shell`
 accept an optional `maxOutputBytes` cap; capped results set `truncated` without
 turning normal command completion into cancellation.
 
+Shell calls use the host's default shell unless they request the explicit
+`shellFlavor: 'posix'` option. POSIX hosts use `/bin/sh`; native Windows hosts
+validate and use a same-host Git Bash installation discovered through
+`FELAN_POSIX_SHELL`, `PATH`, or standard Git-for-Windows locations. The
+`HostAgentRuntimeOptions.posixShell` override is available to embedding hosts.
+The default Windows `cmd.exe` behavior is unchanged, and WSL is not selected
+automatically because its process and path namespace is separate from the host.
+
 Every `AgentRuntime` exposes scoped storage through `storage(scope)`. The
 default `storage()` handle is identical to `storage('session')` and belongs to
 one root session plus all of its subagents. Session storage is readable through

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felan-ai/agent-core",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "description": "Portable Felan agent contracts and composition",
   "license": "MIT",
   "type": "module",

--- a/packages/agent-core/src/host-agent-runtime.ts
+++ b/packages/agent-core/src/host-agent-runtime.ts
@@ -1,5 +1,6 @@
 import { spawn, type ChildProcess } from 'node:child_process';
 import {
+  access,
   lstat,
   mkdir,
   open,
@@ -23,6 +24,7 @@ import type {
   AgentRuntimeProcesses,
   AgentRuntimeProcessReadOptions,
   AgentRuntimeProcessSnapshot,
+  AgentRuntimeShellOptions,
   AgentRuntimeShellProcessOptions,
   AgentRuntimeStorage,
   AgentRuntimeStorageScope,
@@ -31,15 +33,14 @@ import type {
 } from './runtime.js';
 import { fileListingGlobMatcher, normalizeFileListingPath } from './file-listing.js';
 
-export type HostShellOptions = AgentRuntimeExecOptions & {
-  env?: Readonly<Record<string, string>>;
-};
+export type HostShellOptions = AgentRuntimeShellOptions;
 
 export interface HostAgentRuntimeOptions {
   readonly sessionStorageRoot: string;
   readonly agentStorageRoot: string;
   readonly agentDir?: string;
   readonly pathAccess?: 'workspace' | 'host';
+  readonly posixShell?: string;
 }
 
 export class HostAgentRuntime implements AgentRuntime {
@@ -50,6 +51,8 @@ export class HostAgentRuntime implements AgentRuntime {
   readonly #agentStorageRoot: string;
   readonly #agentDir: string | undefined;
   readonly #pathAccess: 'workspace' | 'host';
+  readonly #configuredPosixShell: string | undefined;
+  #posixShell: Promise<string> | undefined;
   readonly processes: AgentRuntimeProcesses;
   readonly terminals: AgentRuntimeTerminals;
 
@@ -62,6 +65,7 @@ export class HostAgentRuntime implements AgentRuntime {
     this.#agentStorageRoot = resolveStorageRoot(options.agentStorageRoot);
     this.#agentDir = options.agentDir === undefined ? undefined : resolveStorageRoot(options.agentDir);
     this.#pathAccess = options.pathAccess ?? 'workspace';
+    this.#configuredPosixShell = validateConfiguredShell(options.posixShell);
     this.#sessionStorage = createHostStorage(this.#sessionStorageRoot);
     this.#agentStorage = createHostStorage(this.#agentStorageRoot);
     this.processes = {
@@ -99,7 +103,45 @@ export class HostAgentRuntime implements AgentRuntime {
   async shell(command: string, options?: HostShellOptions): Promise<ExecResult> {
     const env = options?.env ? { ...options.env } : undefined;
     const cwd = await this.#resolvePath(options?.cwd ?? this.#cwd);
+    if (options?.shellFlavor === 'posix') {
+      const shell = await this.#resolvePosixShell(cwd);
+      return this.#spawn(shell, ['-c', command], cwd, options, false, env);
+    }
     return this.#spawn(command, [], cwd, options, true, env);
+  }
+
+  #resolvePosixShell(cwd: string): Promise<string> {
+    this.#posixShell ??= this.#findPosixShell(cwd);
+    return this.#posixShell;
+  }
+
+  async #findPosixShell(cwd: string): Promise<string> {
+    if (this.#configuredPosixShell) {
+      if (await this.#isCompatiblePosixShell(this.#configuredPosixShell, cwd)) {
+        return this.#configuredPosixShell;
+      }
+      throw new Error(`Configured POSIX shell is unavailable or cannot access the runtime cwd: ${this.#configuredPosixShell}`);
+    }
+
+    if (process.platform !== 'win32') return '/bin/sh';
+
+    for (const candidate of windowsPosixShellCandidates(process.env)) {
+      if (await this.#isCompatiblePosixShell(candidate, cwd)) return candidate;
+    }
+    throw new Error('POSIX shell is unavailable. Install Git Bash or configure HostAgentRuntime.posixShell.');
+  }
+
+  async #isCompatiblePosixShell(shell: string, cwd: string): Promise<boolean> {
+    if (isAbsolute(shell)) {
+      try {
+        await access(shell);
+      } catch {
+        return false;
+      }
+    }
+    const probe = `test -d ${quotePosixPath(cwd)} && printf '%s\\n' __FELAN_POSIX_SHELL__`;
+    const result = await this.#spawn(shell, ['-c', probe], cwd, { timeout: 2_000 }, false);
+    return !result.killed && result.code === 0 && result.stdout.trim() === '__FELAN_POSIX_SHELL__';
   }
 
   async readFile(path: string, options?: AgentRuntimeFileReadOptions): Promise<Uint8Array> {
@@ -163,11 +205,13 @@ export class HostAgentRuntime implements AgentRuntime {
   ): Promise<AgentRuntimeProcess> {
     const cwd = await this.#resolvePath(options?.cwd ?? this.#cwd);
     const shell = options?.shell ?? defaultShell();
+    const useShellOption = process.platform === 'win32' && isCmdShell(shell);
     const args = shellArguments(shell, command, options?.login ?? true);
-    const child = spawn(shell, args, {
+    const child = spawn(useShellOption ? command : shell, useShellOption ? [] : args, {
       cwd,
       detached: process.platform !== 'win32',
       env: options?.env ? { ...process.env, ...options.env } : process.env,
+      shell: useShellOption ? shell : false,
       stdio: [options?.stdin ? 'pipe' : 'ignore', 'pipe', 'pipe'],
       windowsHide: true,
     });
@@ -183,7 +227,10 @@ export class HostAgentRuntime implements AgentRuntime {
     const args = shellArguments(shell, command, options?.login ?? true);
     const env = terminalEnvironment(options?.env);
     const pty = await loadPty();
-    const terminal = pty.spawn(shell, args, {
+    const terminalArgs = process.platform === 'win32' && isCmdShell(shell)
+      ? `/d /s /c "${command}"`
+      : args;
+    const terminal = pty.spawn(shell, terminalArgs, {
       cwd,
       env,
       name: env.TERM ?? 'xterm-256color',
@@ -403,13 +450,19 @@ class HostRuntimeTerminal extends HostBufferedProcess {
   readonly #terminal: IPty;
   readonly #dataSubscription: IDisposable;
   readonly #exitSubscription: IDisposable;
+  #startupOutput = process.platform === 'win32';
 
   constructor(terminal: IPty) {
     super();
     this.#terminal = terminal;
     this.#dataSubscription = terminal.onData((data) => {
       const raw = data as unknown;
-      this.appendOutput(typeof raw === 'string' ? Buffer.from(raw) : new Uint8Array(raw as Buffer));
+      const text = typeof raw === 'string'
+        ? raw
+        : new TextDecoder().decode(new Uint8Array(raw as Buffer));
+      const output = this.#startupOutput ? stripWindowsPtyStartup(text) : text;
+      if (this.#startupOutput && output !== undefined) this.#startupOutput = false;
+      if (output) this.appendOutput(Buffer.from(output));
     });
     this.#exitSubscription = terminal.onExit(({ exitCode, signal }) => {
       this.complete(signal ? 128 + signal : exitCode);
@@ -422,7 +475,12 @@ class HostRuntimeTerminal extends HostBufferedProcess {
 
   async write(content: Uint8Array): Promise<void> {
     if (!this.running) throw new Error('Process has exited');
-    this.#terminal.write(Buffer.from(content));
+    if (process.platform !== 'win32') {
+      this.#terminal.write(Buffer.from(content));
+      return;
+    }
+    const text = Buffer.from(content).toString();
+    this.#terminal.write(text.replace(/\r?\n/gu, '\r\n'));
   }
 
   protected sendSignal(signal: NodeJS.Signals): void {
@@ -710,10 +768,66 @@ function defaultShell(): string {
 }
 
 function shellArguments(shell: string, command: string, login: boolean): string[] {
-  if (process.platform === 'win32' && /(?:^|[\\/])cmd(?:\.exe)?$/iu.test(shell)) {
+  if (process.platform === 'win32' && isCmdShell(shell)) {
     return ['/d', '/s', '/c', command];
   }
   return login ? ['-l', '-c', command] : ['-c', command];
+}
+
+function isCmdShell(shell: string): boolean {
+  return /(?:^|[\\/])cmd(?:\.exe)?$/iu.test(shell);
+}
+
+function stripWindowsPtyStartup(value: string): string | undefined {
+  const marker = '\u001b[?9001h\u001b[?1004h';
+  if (value === marker || marker.startsWith(value)) return undefined;
+  return value.startsWith(marker) ? value.slice(marker.length) : value;
+}
+
+function validateConfiguredShell(shell: string | undefined): string | undefined {
+  if (shell === undefined) return undefined;
+  const normalized = shell.trim();
+  if (normalized.length === 0) throw new Error('Configured POSIX shell cannot be empty');
+  if (normalized.includes('\0')) throw new Error('Configured POSIX shell cannot contain NUL bytes');
+  return normalized;
+}
+
+function windowsPosixShellCandidates(env: NodeJS.ProcessEnv): string[] {
+  const candidates: string[] = [];
+  const add = (candidate: string | undefined): void => {
+    if (!candidate || candidate.includes('\0')) return;
+    if (!candidates.some((existing) => existing.toLowerCase() === candidate.toLowerCase())) {
+      candidates.push(candidate);
+    }
+  };
+
+  add(env.FELAN_POSIX_SHELL);
+  for (const entry of (env.Path ?? env.PATH ?? '').split(';')) {
+    const directory = entry.trim();
+    if (!directory) continue;
+    add(join(directory, 'sh.exe'));
+    add(join(directory, 'bash.exe'));
+  }
+
+  const roots = [
+    env.ProgramW6432,
+    env.ProgramFiles,
+    env['ProgramFiles(x86)'],
+    env.LOCALAPPDATA,
+  ];
+  for (const root of roots) {
+    if (!root) continue;
+    add(join(root, 'Git', 'bin', 'bash.exe'));
+    add(join(root, 'Git', 'bin', 'sh.exe'));
+    add(join(root, 'Git', 'usr', 'bin', 'bash.exe'));
+    add(join(root, 'Git', 'usr', 'bin', 'sh.exe'));
+  }
+  return candidates;
+}
+
+function quotePosixPath(value: string): string {
+  const normalized = process.platform === 'win32' ? value.replaceAll('\\', '/') : value;
+  return `'${normalized.replaceAll("'", `'\\''`)}'`;
 }
 
 function signalExitCode(signal: NodeJS.Signals | null): number {

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -10,6 +10,8 @@ export type {
   AgentRuntimeProcesses,
   AgentRuntimeProcessReadOptions,
   AgentRuntimeProcessSnapshot,
+  AgentRuntimeShellFlavor,
+  AgentRuntimeShellOptions,
   AgentRuntimeShellProcessOptions,
   AgentRuntimeStorage,
   AgentRuntimeStorageScope,
@@ -52,6 +54,7 @@ export type {
 export { createAgentCoreResourceLoader } from './resource-loader.js';
 export type { CreateAgentCoreResourceLoaderOptions } from './resource-loader.js';
 export { createRuntimeCodingTools } from './tools.js';
+export type { RuntimeCodingToolsOptions } from './tools.js';
 export {
   createAgentCoreSession,
   createAgentCoreSessionRuntime,

--- a/packages/agent-core/src/runtime.ts
+++ b/packages/agent-core/src/runtime.ts
@@ -17,6 +17,13 @@ export interface AgentRuntimeExecResult extends PiExecResult {
 
 export type ExecResult = AgentRuntimeExecResult;
 
+export type AgentRuntimeShellFlavor = 'default' | 'posix';
+
+export interface AgentRuntimeShellOptions extends AgentRuntimeExecOptions {
+  readonly env?: Readonly<Record<string, string>>;
+  readonly shellFlavor?: AgentRuntimeShellFlavor;
+}
+
 export type AgentRuntimeKind = 'host' | 'docker' | 'daytona';
 
 export type AgentRuntimeStorageScope = 'session' | 'agent';
@@ -114,7 +121,7 @@ export interface AgentRuntime {
 
   shell(
     command: string,
-    options?: AgentRuntimeExecOptions & { env?: Readonly<Record<string, string>> },
+    options?: AgentRuntimeShellOptions,
   ): Promise<ExecResult>;
 
   readFile(path: string, options?: AgentRuntimeFileReadOptions): Promise<Uint8Array>;

--- a/packages/agent-core/src/tools.ts
+++ b/packages/agent-core/src/tools.ts
@@ -9,13 +9,20 @@ import {
   createWriteToolDefinition,
   type ToolDefinition,
 } from '@earendil-works/pi-coding-agent';
-import type { AgentRuntime } from './runtime.js';
+import type { AgentRuntime, AgentRuntimeShellFlavor } from './runtime.js';
 import { fileListingGlobMatcher, normalizeFileListingPath } from './file-listing.js';
 
 const encoder = new TextEncoder();
 const MAX_RUNTIME_TOOL_OUTPUT_BYTES = 50 * 1024;
 
-export function createRuntimeCodingTools(runtime: AgentRuntime): ToolDefinition<any, any, any>[] {
+export interface RuntimeCodingToolsOptions {
+  readonly shellFlavor?: AgentRuntimeShellFlavor;
+}
+
+export function createRuntimeCodingTools(
+  runtime: AgentRuntime,
+  options?: RuntimeCodingToolsOptions,
+): ToolDefinition<any, any, any>[] {
   const read = createReadToolDefinition(runtime.cwd, {
     operations: {
       access: async (path) => {
@@ -28,6 +35,7 @@ export function createRuntimeCodingTools(runtime: AgentRuntime): ToolDefinition<
   const bash = createBashToolDefinition(runtime.cwd) as ToolDefinition<any, any, any>;
   bash.execute = async (_toolCallId, { command, timeout }, signal) => {
     const result = await runtime.shell(command, {
+      ...(options?.shellFlavor === undefined ? {} : { shellFlavor: options.shellFlavor }),
       ...(signal === undefined ? {} : { signal }),
       ...(timeout === undefined ? {} : { timeout: timeout * 1_000 }),
       maxOutputBytes: MAX_RUNTIME_TOOL_OUTPUT_BYTES,

--- a/packages/agent-core/test/host-agent-runtime.test.ts
+++ b/packages/agent-core/test/host-agent-runtime.test.ts
@@ -362,6 +362,36 @@ describe('HostAgentRuntime', () => {
     expect(result.killed).toBe(false);
   });
 
+  it('runs commands through an explicit POSIX shell without changing the default shell', async () => {
+    const runtime = await createHostRuntime(await createTemporaryDirectory('workspace'));
+    let result;
+    try {
+      result = await runtime.shell('printf "%s" "$FELAN_POSIX_TEST"', {
+        env: { FELAN_POSIX_TEST: 'posix works' },
+        shellFlavor: 'posix',
+      });
+    } catch (error) {
+      if (process.platform === 'win32' && error instanceof Error && error.message.includes('POSIX shell')) return;
+      throw error;
+    }
+
+    expect(result).toMatchObject({ stdout: 'posix works', code: 0, killed: false });
+  });
+
+  it('rejects an explicitly unavailable POSIX shell', async () => {
+    const workspace = await createTemporaryDirectory('workspace');
+    const storage = await createTemporaryDirectory('storage');
+    const runtime = new HostAgentRuntime(workspace, {
+      sessionStorageRoot: join(storage, 'session'),
+      agentStorageRoot: join(storage, 'agent'),
+      posixShell: process.platform === 'win32' ? 'C:\\missing\\felan-posix-shell.exe' : '/missing/felan-posix-shell',
+    });
+    await mkdir(join(storage, 'session'), { recursive: true });
+    await mkdir(join(storage, 'agent'), { recursive: true });
+
+    await expect(runtime.shell('printf nope', { shellFlavor: 'posix' })).rejects.toThrow('Configured POSIX shell');
+  });
+
   it('reads only files inside its configured agent directory', async () => {
     const workspace = await createTemporaryDirectory('workspace');
     const storageRoot = await createTemporaryDirectory('storage');

--- a/packages/agent-core/test/test-agent-runtime.ts
+++ b/packages/agent-core/test/test-agent-runtime.ts
@@ -5,14 +5,13 @@ import type {
   AgentRuntimeFileReadOptions,
   AgentRuntimeFileWriteOptions,
   AgentRuntimeKind,
+  AgentRuntimeShellOptions,
   AgentRuntimeStorage,
   AgentRuntimeStorageScope,
   ExecResult,
 } from '../src/runtime.js';
 
-type TestShellOptions = AgentRuntimeExecOptions & {
-  env?: Readonly<Record<string, string>>;
-};
+type TestShellOptions = AgentRuntimeShellOptions;
 
 interface TestExecCall {
   readonly command: string;
@@ -251,7 +250,12 @@ export class TestAgentRuntime implements AgentRuntime {
 
   #normalizeShellOptions(options?: TestShellOptions): TestShellOptions | undefined {
     const normalized = this.#normalizeExecOptions(options);
-    return options?.env ? { ...normalized, env: { ...options.env } } : normalized;
+    if (!options) return normalized;
+    return {
+      ...normalized,
+      ...(options.env === undefined ? {} : { env: { ...options.env } }),
+      ...(options.shellFlavor === undefined ? {} : { shellFlavor: options.shellFlavor }),
+    };
   }
 
   async #run(

--- a/packages/agent-core/test/tools.test.ts
+++ b/packages/agent-core/test/tools.test.ts
@@ -41,6 +41,21 @@ describe('runtime-backed coding tools', () => {
     }
   });
 
+  it('can route the Bash coding tool through an explicit POSIX shell', async () => {
+    const runtime = new TestAgentRuntime('/virtual-felan-workspace');
+    const tools = toolsByName(createRuntimeCodingTools(runtime, { shellFlavor: 'posix' }));
+
+    await tools.bash!.execute(
+      'bash-posix',
+      { command: 'printf posix' },
+      undefined,
+      undefined,
+      context,
+    );
+
+    expect(runtime.shellCalls[0]?.options).toMatchObject({ shellFlavor: 'posix' });
+  });
+
   it('routes shell and grep execution through runtime operations with safe argv boundaries', async () => {
     const runtime = new TestAgentRuntime('/virtual-felan-workspace', {
       shell: ({ command }) => ({ stdout: command, stderr: '', code: 0, killed: false }),

--- a/packages/ext-background-bash/README.md
+++ b/packages/ext-background-bash/README.md
@@ -10,20 +10,29 @@ adapters map it to their root-session state path.
 
 The implementation routes filesystem and process operations through the active
 `AgentRuntime`. Background launch uses a detached POSIX shell runner. Host,
-Docker, and Daytona runtimes need `nohup`, `ps`, and either `setsid` or shell job
-control so each process receives an isolated process group. The extension
+Docker, and Daytona runtimes need `nohup`, `ps`, `sleep`, and either `setsid`
+or shell job control so each process receives an isolated process group. The extension
 captures `runtime.storage('session')` once; that handle must be
 durable and visible in the same filesystem namespace as `runtime.shell`.
-It probes the required POSIX shell/process utilities through `AgentRuntime` and
-leaves its tools inactive when the runtime is incompatible. The local TUI can
-persistently disable the extension through dependency onboarding; Felan does
-not install operating-system utilities.
+It requests the explicit POSIX shell flavor for probing and execution, then
+leaves its tools inactive when the runtime is incompatible. On native Windows,
+`HostAgentRuntime` discovers a same-host Git Bash installation through
+`FELAN_POSIX_SHELL`, `PATH`, or standard Git-for-Windows locations. WSL is not
+selected automatically because its path and process namespace does not match
+the host runtime. Git Bash's process tools use its `ps -l` format when GNU
+`ps -o` is unavailable. The local TUI can persistently disable the extension
+through dependency onboarding; Felan does not install operating-system
+utilities.
 
 The extension activates for selected models outside the OpenAI provider family.
 OpenAI and OpenAI Codex sessions use the separate Codex-specific process
 surface instead. Keeping eligibility here gives cloud and local consumers
 identical behavior without duplicating model filters in their composition
 roots.
+
+This release requires `@felan-ai/agent-core` 0.4.11 or newer within the 0.x
+compatible-minor range because it uses the runtime's explicit POSIX shell
+flavor.
 
 ## Tools and controls
 

--- a/packages/ext-background-bash/package.json
+++ b/packages/ext-background-bash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felan-ai/ext-background-bash",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Runtime-portable detached Bash processes for Felan",
   "license": "MIT",
   "type": "module",
@@ -30,7 +30,7 @@
     "typebox": "1.1.38"
   },
   "peerDependencies": {
-    "@felan-ai/agent-core": "^0.4.0"
+    "@felan-ai/agent-core": ">=0.4.11 <0.5.0"
   },
   "devDependencies": {
     "@felan-ai/agent-core": "workspace:*"

--- a/packages/ext-background-bash/package.json
+++ b/packages/ext-background-bash/package.json
@@ -30,7 +30,7 @@
     "typebox": "1.1.38"
   },
   "peerDependencies": {
-    "@felan-ai/agent-core": ">=0.4.11 <0.5.0"
+    "@felan-ai/agent-core": "^0.4.11"
   },
   "devDependencies": {
     "@felan-ai/agent-core": "workspace:*"

--- a/packages/ext-background-bash/src/index.ts
+++ b/packages/ext-background-bash/src/index.ts
@@ -94,7 +94,7 @@ export function supportsBackgroundBashModel(model: Model<Api> | undefined): bool
 
 const backgroundBashExtension: FelanExtension = (pi) => {
   const manager = new BackgroundBashManager(pi.runtime);
-  const foregroundBash = createRuntimeCodingTools(pi.runtime)
+  const foregroundBash = createRuntimeCodingTools(pi.runtime, { shellFlavor: 'posix' })
     .find((tool) => tool.name === 'bash')!;
   let helperToolsRegistered = false;
   let backgroundBashActive = false;

--- a/packages/ext-background-bash/src/job-store.ts
+++ b/packages/ext-background-bash/src/job-store.ts
@@ -236,6 +236,7 @@ export class BackgroundBashJobStore {
   ): Promise<BackgroundBashJob | undefined> {
     const job = await this.readJob(id);
     if (!job) return undefined;
+    if (isTerminalStatus(job.status.status) && job.status.status !== patch.status) return job;
     const now = Date.now();
     const status: BackgroundBashStatusFile = {
       ...job.status,

--- a/packages/ext-background-bash/src/process-manager.ts
+++ b/packages/ext-background-bash/src/process-manager.ts
@@ -276,7 +276,8 @@ export class BackgroundBashManager {
   }
 
   #sendSignal(pid: number, signal: NodeJS.Signals) {
-    return this.runtime.shell(`kill -${signal.slice(3)} -- ${shellQuote(String(pid))}`, {
+    const target = pid < 0 ? String(pid) : `-- ${shellQuote(String(pid))}`;
+    return this.runtime.shell(`kill -${signal.slice(3)} ${target}`, {
       cwd: this.runtime.cwd,
       shellFlavor: 'posix',
     });

--- a/packages/ext-background-bash/src/process-manager.ts
+++ b/packages/ext-background-bash/src/process-manager.ts
@@ -1,3 +1,4 @@
+import { join } from 'node:path';
 import type { AgentRuntime, AgentRuntimeStorage } from '@felan-ai/agent-core';
 import { createOutputLog, readLogTail } from './logs.js';
 import {
@@ -14,7 +15,10 @@ export interface WaitBackgroundBashResult {
 
 const WAIT_POLL_MS = 500;
 const PROCESS_STATUS_GRACE_MS = 5_000;
+const STOP_PROCESS_WAIT_MS = 5_000;
+const RUNNER_MARKER_MAX_AGE_SECONDS = 3;
 const encoder = new TextEncoder();
+const decoder = new TextDecoder();
 
 export class BackgroundBashManager {
   readonly #store: BackgroundBashJobStore;
@@ -37,6 +41,7 @@ export class BackgroundBashManager {
         job.meta.processToken!,
       ), {
         cwd: this.runtime.cwd,
+        shellFlavor: 'posix',
         timeout: 10_000,
       });
       if (launch.killed || launch.code !== 0) {
@@ -98,12 +103,19 @@ export class BackgroundBashManager {
   }
 
   async stop(id: string, signal: NodeJS.Signals = 'SIGTERM'): Promise<BackgroundBashJob> {
-    const job = await this.get(id);
+    let job = await this.get(id);
     if (isTerminalStatus(job.status.status)) return job;
 
     const pid = job.status.pid ?? job.meta.pid;
-    const inspected = pid ? await this.#inspectJobProcess(job, pid) : undefined;
+    const inspection = pid
+      ? await this.#inspectForStop(job, pid)
+      : { job, inspected: undefined };
+    job = inspection.job;
+    if (isTerminalStatus(job.status.status)) return job;
+    const inspected = inspection.inspected;
     if (!pid || !inspected) {
+      const latest = await this.#store.readJob(id);
+      if (latest && isTerminalStatus(latest.status.status)) return latest;
       const unknown = await this.#store.markStatus(id, {
         status: 'unknown',
         ...(pid === undefined ? {} : { pid }),
@@ -125,6 +137,18 @@ export class BackgroundBashManager {
       throw new Error(result.stderr || `Unable to send ${signal} to Background Bash process ${id}`);
     }
 
+    if (!await this.#waitForProcessExit(pid)) {
+      return await this.#store.markStatus(id, {
+        status: 'unknown',
+        pid,
+        exitCode: null,
+        signal: null,
+        error: `Process did not exit after ${STOP_PROCESS_WAIT_MS / 1_000} seconds.`,
+      }) ?? job;
+    }
+
+    const completed = await this.#store.readJob(id);
+    if (completed && isTerminalStatus(completed.status.status)) return completed;
     const killed = await this.#store.markStatus(id, {
       status: 'killed',
       pid,
@@ -148,6 +172,8 @@ export class BackgroundBashManager {
     if (now - job.status.startedAt <= PROCESS_STATUS_GRACE_MS) return job;
     if (pid && await this.#isJobProcessAlive(job, pid)) return job;
 
+    const latest = await this.#store.readJob(job.meta.id);
+    if (latest && isTerminalStatus(latest.status.status)) return latest;
     return await this.#store.markStatus(job.meta.id, {
       status: 'unknown',
       ...(pid === undefined ? {} : { pid }),
@@ -163,25 +189,66 @@ export class BackgroundBashManager {
     return await this.#inspectJobProcess(job, pid) !== undefined;
   }
 
+  async #inspectForStop(
+    job: BackgroundBashJob,
+    pid: number,
+  ): Promise<{ job: BackgroundBashJob; inspected?: { processGroupId: number } }> {
+    let latest = job;
+    const deadline = Date.now() + PROCESS_STATUS_GRACE_MS;
+    while (true) {
+      latest = await this.#store.readJob(job.meta.id) ?? latest;
+      if (isTerminalStatus(latest.status.status)) return { job: latest };
+      const inspected = await this.#inspectJobProcess(latest, pid);
+      if (inspected) return { job: latest, inspected };
+      if (Date.now() >= deadline) return { job: latest };
+      await sleep(50);
+    }
+  }
+
+  async #waitForProcessExit(pid: number): Promise<boolean> {
+    const deadline = Date.now() + STOP_PROCESS_WAIT_MS;
+    while (Date.now() < deadline) {
+      if (!await this.#isProcessAlive(pid)) return true;
+      await sleep(Math.min(50, deadline - Date.now()));
+    }
+    return !await this.#isProcessAlive(pid);
+  }
+
+  async #isProcessAlive(pid: number): Promise<boolean> {
+    const result = await this.runtime.shell(`kill -0 -- ${shellQuote(String(pid))} 2>/dev/null`, {
+      cwd: this.runtime.cwd,
+      shellFlavor: 'posix',
+    });
+    return result.code === 0;
+  }
+
   async #inspectJobProcess(
     job: BackgroundBashJob,
     pid: number,
   ): Promise<{ processGroupId: number } | undefined> {
-    const result = await this.runtime.exec(
-      'ps',
-      ['-o', 'pgid=', '-o', 'command=', '-p', String(pid)],
-      { cwd: this.runtime.cwd },
-    );
+    const result = await this.runtime.shell(createInspectCommand(pid), {
+      cwd: this.runtime.cwd,
+      shellFlavor: 'posix',
+    });
     if (result.code !== 0) return undefined;
-    const match = result.stdout.match(/^\s*(\d+)\s+([\s\S]+?)\s*$/u);
-    if (!match) return undefined;
-    const processGroupId = Number(match[1]);
-    if (!Number.isSafeInteger(processGroupId) || processGroupId <= 0) return undefined;
-    const command = match[2] ?? '';
+    const inspected = parseProcessInspection(result.stdout);
+    if (!inspected) return undefined;
+    const { processGroupId, command } = inspected;
+    const expectedProcessGroupId = job.meta.processGroupId ?? pid;
+    const isGitBashShell = /(?:^|\/)(?:sh|bash)(?:\.exe)?$/iu.test(command);
+    const markerMatches = isGitBashShell && await this.#runnerMarkerMatches(job, pid);
+    const matchesGitBashProcess = isGitBashShell
+      && processGroupId === expectedProcessGroupId
+      && processGroupId === pid
+      && markerMatches;
     if (job.meta.processToken) {
-      if (!command.includes(job.meta.runnerPath) || !command.includes(job.meta.processToken)) return undefined;
+      if (
+        (!containsPosixPath(command, job.meta.runnerPath) || !command.includes(job.meta.processToken))
+        && !matchesGitBashProcess
+      ) return undefined;
     } else if (
-      !command.includes(job.meta.runnerPath)
+      !containsPosixPath(command, job.meta.runnerPath)
+      && !matchesGitBashProcess
       && !(command.includes('PI_BG_INFO_PATH') && command.includes('PI_BG_COMMAND'))
     ) {
       return undefined;
@@ -189,9 +256,29 @@ export class BackgroundBashManager {
     return { processGroupId };
   }
 
+  async #runnerMarkerMatches(job: BackgroundBashJob, pid: number): Promise<boolean> {
+    if (!job.meta.processToken) return false;
+    try {
+      const markerPath = join(job.meta.jobDir, 'runner-heartbeat');
+      const [id, token, markerPid, timestamp] = decoder
+        .decode(await this.#storage.readFile(markerPath))
+        .trim()
+        .split(/\r?\n/u);
+      const markerTimestamp = Number(timestamp);
+      return id === job.meta.id
+        && token === job.meta.processToken
+        && markerPid === String(pid)
+        && Number.isSafeInteger(markerTimestamp)
+        && Math.abs(Math.floor(Date.now() / 1_000) - markerTimestamp) <= RUNNER_MARKER_MAX_AGE_SECONDS;
+    } catch {
+      return false;
+    }
+  }
+
   #sendSignal(pid: number, signal: NodeJS.Signals) {
-    return this.runtime.exec('kill', [`-${signal.slice(3)}`, '--', String(pid)], {
+    return this.runtime.shell(`kill -${signal.slice(3)} -- ${shellQuote(String(pid))}`, {
       cwd: this.runtime.cwd,
+      shellFlavor: 'posix',
     });
   }
 }
@@ -209,6 +296,14 @@ function createLaunchCommand(runnerPath: string, processToken: string): string {
     `  nohup sh ${path} ${token} >/dev/null 2>&1 < /dev/null &`,
     '  pid="$!"',
     "  process_group=$(ps -o pgid= -p \"$pid\" 2>/dev/null | tr -d ' ')",
+    '  if [ -z "$process_group" ]; then',
+    '    process_group=$(ps -l -p "$pid" 2>/dev/null | {',
+    '      IFS= read -r header',
+    '      IFS= read -r row',
+    '      set -- $row',
+    '      printf "%s\\n" "${3:-}"',
+    '    })',
+    '  fi',
     '  if [ "$process_group" = "$pid" ]; then',
     "    printf 'group:%s:%s\\n' \"$pid\" \"$process_group\"",
     '  else',
@@ -221,19 +316,62 @@ function createLaunchCommand(runnerPath: string, processToken: string): string {
   ].join('\n');
 }
 
+function createInspectCommand(pid: number): string {
+  const quotedPid = shellQuote(String(pid));
+  return `ps -o pgid= -o command= -p ${quotedPid} 2>/dev/null || ps -l -p ${quotedPid} 2>/dev/null`;
+}
+
+function parseProcessInspection(output: string): { processGroupId: number; command: string } | undefined {
+  const lines = output.split(/\r?\n/u).map((line) => line.trim()).filter(Boolean);
+  const compact = lines[0]?.match(/^(\d+)\s+(.+)$/u);
+  if (compact) {
+    const processGroupId = Number(compact[1]);
+    if (Number.isSafeInteger(processGroupId) && processGroupId > 0) {
+      return { processGroupId, command: compact[2] ?? '' };
+    }
+  }
+
+  for (const line of lines) {
+    const fields = line.split(/\s+/u);
+    if (fields.length < 8 || !/^\d+$/u.test(fields[0] ?? '') || !/^\d+$/u.test(fields[2] ?? '')) continue;
+    const processGroupId = Number(fields[2]);
+    if (!Number.isSafeInteger(processGroupId) || processGroupId <= 0) continue;
+    return { processGroupId, command: fields.slice(7).join(' ') };
+  }
+  return undefined;
+}
+
 function createRunnerScript(job: BackgroundBashJob): string {
   const id = shellQuote(job.meta.id);
+  const processToken = shellQuote(job.meta.processToken ?? '');
   const commandPath = shellQuote(job.meta.commandPath);
   const completionPath = shellQuote(job.meta.completionPath);
   const outputPath = shellQuote(job.meta.logPath);
+  const markerPath = shellQuote(join(job.meta.jobDir, 'runner-heartbeat'));
   return `#!/bin/sh
 set +e
 job_id=${id}
+process_token=${processToken}
 command_path=${commandPath}
 completion_path=${completionPath}
 output_path=${outputPath}
+marker_path=${markerPath}
 started_at=${job.meta.startedAt}
 child_pid=
+heartbeat_pid=
+
+write_heartbeat() {
+  timestamp=$(date +%s)
+  tmp_path="$marker_path.$$.$timestamp.tmp"
+  printf '%s\\n%s\\n%s\\n%s\\n' "$job_id" "$process_token" "$$" "$timestamp" > "$tmp_path"
+  mv "$tmp_path" "$marker_path"
+}
+
+heartbeat() {
+  while write_heartbeat; do
+    sleep 1
+  done
+}
 
 write_completion() {
   status="$1"
@@ -263,6 +401,10 @@ EOF
 
 terminate() {
   signal_name="$1"
+  if [ -n "$heartbeat_pid" ]; then
+    kill "$heartbeat_pid" 2>/dev/null
+    wait "$heartbeat_pid" 2>/dev/null
+  fi
   short_signal=\${signal_name#SIG}
   if [ -n "$child_pid" ]; then
     kill -"$short_signal" "$child_pid" 2>/dev/null
@@ -276,11 +418,19 @@ trap 'terminate SIGTERM' TERM
 trap 'terminate SIGINT' INT
 trap 'terminate SIGHUP' HUP
 
+heartbeat &
+heartbeat_pid=$!
+
 sh "$command_path" >> "$output_path" 2>&1 &
 child_pid=$!
 wait "$child_pid"
 exit_code=$?
 trap - TERM INT HUP
+
+if [ -n "$heartbeat_pid" ]; then
+  kill "$heartbeat_pid" 2>/dev/null
+  wait "$heartbeat_pid" 2>/dev/null
+fi
 
 if [ ! -f "$completion_path" ]; then
   if [ "$exit_code" -eq 0 ]; then
@@ -306,7 +456,17 @@ function parseLaunchResult(output: string): { pid: number; processGroupId?: numb
 }
 
 function shellQuote(value: string): string {
-  return `'${value.replaceAll("'", `'\\''`)}'`;
+  const normalized = process.platform === 'win32' ? value.replaceAll('\\', '/') : value;
+  return `'${normalized.replaceAll("'", `'\\''`)}'`;
+}
+
+function containsPosixPath(command: string, path: string): boolean {
+  const normalizedPath = path.replaceAll('\\', '/');
+  const variants = [normalizedPath];
+  const drivePath = normalizedPath.match(/^([a-z]):\/(.*)$/iu);
+  if (drivePath) variants.push(`/${drivePath[1]!.toLowerCase()}/${drivePath[2]}`);
+  const normalizedCommand = command.replaceAll('\\', '/');
+  return variants.some((variant) => normalizedCommand.includes(variant));
 }
 
 function sleep(ms: number, signal?: AbortSignal): Promise<void> {

--- a/packages/ext-background-bash/src/runtime-support.ts
+++ b/packages/ext-background-bash/src/runtime-support.ts
@@ -1,6 +1,6 @@
 import type { AgentRuntime } from '@felan-ai/agent-core';
 
-const REQUIRED_POSIX_COMMANDS = ['sh', 'nohup', 'ps', 'tr', 'kill', 'date', 'cat', 'mv'] as const;
+const REQUIRED_POSIX_COMMANDS = ['sh', 'nohup', 'ps', 'tr', 'kill', 'date', 'cat', 'mv', 'sleep'] as const;
 const PROBE_TIMEOUT_MS = 5_000;
 
 export type BackgroundBashRuntimeStatus = {
@@ -27,6 +27,7 @@ export async function inspectBackgroundBashRuntime(
   try {
     const result = await runtime.shell(script, {
       cwd: runtime.cwd,
+      shellFlavor: 'posix',
       timeout: PROBE_TIMEOUT_MS,
     });
     if (!result.killed && result.code === 0) return { available: true };

--- a/packages/ext-background-bash/test/extension.test.ts
+++ b/packages/ext-background-bash/test/extension.test.ts
@@ -65,6 +65,10 @@ describe('background bash extension activation', () => {
 
     expect(harness.registerTool).not.toHaveBeenCalled();
     expect(runtime.shell).toHaveBeenCalledOnce();
+    expect(runtime.shell).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ shellFlavor: 'posix' }),
+    );
   });
 
   it('activates when the selected model changes from OpenAI to another provider', async () => {
@@ -112,7 +116,10 @@ describe('background bash extension activation', () => {
 
     await expect(bash.execute('call', { command: 'sleep 5', timeout: 2 }, undefined, undefined, context('anthropic')))
       .rejects.toThrow('Command timed out after 2 seconds');
-    expect(shell).toHaveBeenCalledWith('sleep 5', expect.objectContaining({ timeout: 2_000 }));
+    expect(shell).toHaveBeenCalledWith(
+      'sleep 5',
+      expect.objectContaining({ shellFlavor: 'posix', timeout: 2_000 }),
+    );
   });
 
   it('steers terminal process completion into the parent session automatically', async () => {

--- a/packages/ext-background-bash/test/process-manager.test.ts
+++ b/packages/ext-background-bash/test/process-manager.test.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs';
 import { mkdir, mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -53,6 +54,42 @@ describe('BackgroundBashManager', () => {
       'Background Bash process not found: ../../outside',
     );
   });
+
+  it('stops a process immediately after launch without losing runner identity', async () => {
+    const { manager } = await createManager();
+    const started = await manager.start('sleep 30');
+
+    const stopped = await manager.stop(started.meta.id, 'SIGTERM');
+
+    expect(stopped.status).toMatchObject({ status: 'killed', signal: 'SIGTERM' });
+  });
+
+  it('does not replace natural completion with an unknown stop result', async () => {
+    const { manager } = await createManager();
+    const started = await manager.start('sleep 1; printf done');
+
+    const stopped = await manager.stop(started.meta.id, 'SIGTERM');
+
+    expect(['completed', 'killed']).toContain(stopped.status.status);
+    expect(stopped.status.status).not.toBe('unknown');
+  });
+
+  it.skipIf(process.platform !== 'win32' || !nativeGitBashAvailable())(
+    'runs and stops a detached process through native Git Bash process groups',
+    async () => {
+      const { manager } = await createManager();
+      const started = await manager.start("printf 'windows git bash\\n'");
+      const completed = await manager.wait(started.meta.id, 10);
+
+      expect(completed.job.status).toMatchObject({ status: 'completed', exitCode: 0 });
+      await expect(manager.tail(started.meta.id)).resolves.toContain('windows git bash');
+
+      const running = await manager.start('sleep 30');
+      await expect(manager.stop(running.meta.id)).resolves.toMatchObject({
+        status: { status: 'killed', signal: 'SIGTERM' },
+      });
+    },
+  );
 });
 
 async function createManager(): Promise<{
@@ -60,7 +97,7 @@ async function createManager(): Promise<{
   runtime: HostAgentRuntime;
   storageScopes: AgentRuntimeStorageScope[];
 }> {
-  const root = await mkdtemp(join(tmpdir(), 'felan-background-bash-'));
+  const root = await mkdtemp(join(tmpdir(), 'felan background bash spaces-'));
   temporaryPaths.push(root);
   const cwd = join(root, 'workspace');
   const sessionStorageRoot = join(root, 'session-storage');
@@ -101,14 +138,32 @@ async function readPid(runtime: HostAgentRuntime, path: string): Promise<number>
 async function waitForProcessExit(runtime: HostAgentRuntime, pid: number): Promise<void> {
   let processInfo = '';
   for (let attempt = 0; attempt < 40; attempt += 1) {
-    const result = await runtime.exec(
-      'ps',
-      ['-o', 'stat=', '-o', 'ppid=', '-o', 'pgid=', '-o', 'command=', '-p', String(pid)],
-    );
+    const result = await runtime.shell(`kill -0 -- ${String(pid)} 2>/dev/null`, {
+      shellFlavor: 'posix',
+    });
     processInfo = result.stdout.trim();
-    const state = processInfo.match(/^(\S+)/u)?.[1] ?? '';
-    if (result.code !== 0 || state === '' || state.startsWith('Z')) return;
+    if (result.code !== 0) return;
     await new Promise((resolve) => setTimeout(resolve, 50));
   }
   throw new Error(`Descendant process ${pid} is still running: ${processInfo}`);
+}
+
+function nativeGitBashAvailable(): boolean {
+  const pathEntries = (process.env.Path ?? process.env.PATH ?? '').split(';').filter(Boolean);
+  const roots = [
+    process.env.ProgramW6432,
+    process.env.ProgramFiles,
+    process.env['ProgramFiles(x86)'],
+    process.env.LOCALAPPDATA,
+  ].filter((value): value is string => Boolean(value));
+  const candidates = [
+    process.env.FELAN_POSIX_SHELL,
+    ...pathEntries.flatMap((entry) => [join(entry, 'bash.exe'), join(entry, 'sh.exe')]),
+    ...roots.flatMap((root) => [
+      join(root, 'Git', 'bin', 'bash.exe'),
+      join(root, 'Git', 'bin', 'sh.exe'),
+      join(root, 'Git', 'usr', 'bin', 'sh.exe'),
+    ]),
+  ];
+  return candidates.some((candidate) => candidate !== undefined && existsSync(candidate));
 }


### PR DESCRIPTION
## Summary
- route Background Bash POSIX calls through an explicit same-host POSIX shell on native Windows
- discover and validate Git Bash while preserving default cmd.exe behavior
- adapt Git Bash process inspection, identity, paths, and stop synchronization
- preserve Agent Core bounded-output/file-listing and Felan API changes from main

## Verification
- Agent Core: 71 passed, 5 skipped
- Background Bash: 24 passed, including native Git Bash and stop-race coverage
- Felan API: 18 passed
- TUI: 194 passed, 1 pre-existing ext-memory projection failure on native Windows
- `pnpm check:proposed-version`: passed
- direct license inventory: passed

The native Windows `pnpm check:licenses` wrapper remains unable to spawn `pnpm` and is unrelated to this change; Linux CI should run the repository gate.