### PR TITLE
test: stabilize Background Bash integration timeout

### DIFF
--- a/packages/ext-background-bash/test/extension.test.ts
+++ b/packages/ext-background-bash/test/extension.test.ts
@@ -14,6 +14,7 @@ import backgroundBashExtension from '../src/index.js';
 
 type Handler = (event: any, ctx: ExtensionContext) => unknown;
 const temporaryPaths: string[] = [];
+const INTEGRATION_TEST_TIMEOUT_MS = 15_000;
 
 afterEach(async () => {
   await Promise.all(temporaryPaths.splice(0).map((path) => rm(path, { recursive: true, force: true })));
@@ -150,7 +151,7 @@ describe('background bash extension activation', () => {
     expect(JSON.stringify(message.details)).not.toContain('processToken');
 
     await harness.emit('session_shutdown', {}, ctx);
-  });
+  }, INTEGRATION_TEST_TIMEOUT_MS);
 
   it('reads stored output without sending a second completion after wait finishes', async () => {
     const harness = createHarness(await createHostRuntime());

--- a/packages/ext-background-bash/test/process-manager.test.ts
+++ b/packages/ext-background-bash/test/process-manager.test.ts
@@ -9,6 +9,7 @@ import { BackgroundBashManager } from '../src/process-manager.js';
 
 const temporaryPaths: string[] = [];
 const INTEGRATION_TEST_TIMEOUT_MS = 15_000;
+const INTEGRATION_WAIT_TIMEOUT_SECONDS = 30;
 
 afterEach(async () => {
   await Promise.all(temporaryPaths.splice(0).map((path) => rm(path, { recursive: true, force: true })));
@@ -29,7 +30,7 @@ describe('BackgroundBashManager', () => {
     const { manager, runtime, storageScopes } = await createManager();
     const started = await manager.start("printf 'first\\nsecond\\n'");
 
-    const result = await manager.wait(started.meta.id, 10);
+    const result = await manager.wait(started.meta.id, INTEGRATION_WAIT_TIMEOUT_SECONDS);
 
     expect(result.timedOut).toBe(false);
     expect(result.job.status).toMatchObject({ status: 'completed', exitCode: 0 });
@@ -80,7 +81,7 @@ describe('BackgroundBashManager', () => {
     async () => {
       const { manager } = await createManager();
       const started = await manager.start("printf 'windows git bash\\n'");
-      const completed = await manager.wait(started.meta.id, 10);
+      const completed = await manager.wait(started.meta.id, INTEGRATION_WAIT_TIMEOUT_SECONDS);
 
       expect(completed.job.status).toMatchObject({ status: 'completed', exitCode: 0 });
       await expect(manager.tail(started.meta.id)).resolves.toContain('windows git bash');

--- a/packages/ext-background-bash/test/process-manager.test.ts
+++ b/packages/ext-background-bash/test/process-manager.test.ts
@@ -8,6 +8,7 @@ import { getBackgroundBashJobsDir } from '../src/job-store.js';
 import { BackgroundBashManager } from '../src/process-manager.js';
 
 const temporaryPaths: string[] = [];
+const INTEGRATION_TEST_TIMEOUT_MS = 15_000;
 
 afterEach(async () => {
   await Promise.all(temporaryPaths.splice(0).map((path) => rm(path, { recursive: true, force: true })));
@@ -39,7 +40,7 @@ describe('BackgroundBashManager', () => {
     expect(storageScopes).toEqual(['session']);
     await expect(manager.tail(started.meta.id)).resolves.toContain('first\nsecond');
     await expect(manager.list('completed')).resolves.toHaveLength(1);
-  });
+  }, INTEGRATION_TEST_TIMEOUT_MS);
 
   it('stops a running process and rejects ids outside the process registry', async () => {
     const { manager, runtime } = await createManager();
@@ -53,7 +54,7 @@ describe('BackgroundBashManager', () => {
     await expect(manager.get('../../outside')).rejects.toThrow(
       'Background Bash process not found: ../../outside',
     );
-  });
+  }, INTEGRATION_TEST_TIMEOUT_MS);
 
   it('stops a process immediately after launch without losing runner identity', async () => {
     const { manager } = await createManager();
@@ -62,7 +63,7 @@ describe('BackgroundBashManager', () => {
     const stopped = await manager.stop(started.meta.id, 'SIGTERM');
 
     expect(stopped.status).toMatchObject({ status: 'killed', signal: 'SIGTERM' });
-  });
+  }, INTEGRATION_TEST_TIMEOUT_MS);
 
   it('does not replace natural completion with an unknown stop result', async () => {
     const { manager } = await createManager();
@@ -72,7 +73,7 @@ describe('BackgroundBashManager', () => {
 
     expect(['completed', 'killed']).toContain(stopped.status.status);
     expect(stopped.status.status).not.toBe('unknown');
-  });
+  }, INTEGRATION_TEST_TIMEOUT_MS);
 
   it.skipIf(process.platform !== 'win32' || !nativeGitBashAvailable())(
     'runs and stops a detached process through native Git Bash process groups',
@@ -89,6 +90,7 @@ describe('BackgroundBashManager', () => {
         status: { status: 'killed', signal: 'SIGTERM' },
       });
     },
+    INTEGRATION_TEST_TIMEOUT_MS,
   );
 });
 


### PR DESCRIPTION
## Summary
- increase Background Bash process-manager integration timeouts from Vitest's 5-second default to 15 seconds
- keep the test behavior unchanged while avoiding false failures under the repository's parallel workspace test load

## Verification
- `pnpm --filter @felan-ai/ext-background-bash exec tsc -p tsconfig.build.json`
- `pnpm --filter @felan-ai/ext-background-bash type-check`
- `pnpm --filter @felan-ai/ext-background-bash exec vitest run --maxWorkers=1` (24 passed)

This follows post-merge CI run 32720427886, where the first integration test timed out under parallel workspace load; the same test module passed in isolation and in PR verification.