### PR TITLE
feat(tui): add local session resume picker (BUG-391)

### DIFF
--- a/apps/tui/README.md
+++ b/apps/tui/README.md
@@ -40,6 +40,9 @@ felan --continue
 felan [options] [message]
 
 -c, --continue     Continue the most recent session for this directory
+-r, --resume       Pick a session to resume
+--session <id>     Resume a specific session
+--session-dir <dir> Session directory for --session
 --diagnostics      Print runtime versions and configuration mode
 update             Update a global npm installation of Felan
 -h, --help         Show help
@@ -64,6 +67,12 @@ Invocations that start or continue an agent session launch the interactive TUI.
 `felan update` and informational flags exit without starting a session. Internal
 headless modes used by subagents and extension adapters are not public CLI entry
 points.
+
+`felan --resume` opens a selection-only session picker. Press Tab to switch
+between the current folder and all local sessions, Ctrl+S to change sorting,
+Ctrl+N to filter to named sessions, and Ctrl+P to toggle session paths. Escape
+cancels without creating a session. `felan --continue` remains the quick path
+for the most recent session in the current directory.
 
 `felan --diagnostics` reports Felan, Agent Core, Pi, and Node.js versions plus
 runtime and credential modes.

--- a/apps/tui/package.json
+++ b/apps/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felan-ai/felan",
-  "version": "0.13.8",
+  "version": "0.13.9",
   "description": "Local Felan terminal agent",
   "license": "MIT",
   "type": "module",

--- a/apps/tui/src/application.ts
+++ b/apps/tui/src/application.ts
@@ -14,6 +14,13 @@ export interface RunLocalFelanOptions extends CreateLocalFelanRuntimeOptions {
   readonly verbose?: boolean;
 }
 
+export function brandResumeHint(output: string): string {
+  return output.replace(
+    /(To resume this session:(?:\x1b\[[0-9;]*m)*\s*)pi /,
+    '$1felan ',
+  );
+}
+
 export async function runLocalFelan(options: RunLocalFelanOptions = {}): Promise<void> {
   let nextOptions = options;
   while (true) {
@@ -43,6 +50,11 @@ async function runLocalFelanSession(options: RunLocalFelanOptions): Promise<stri
   process.env.PI_CODING_AGENT_DIR = runtime.services.agentDir;
   process.env.PI_SKIP_VERSION_CHECK = '1';
   process.env.PI_TELEMETRY = '0';
+  const previousStdoutWrite = process.stdout.write;
+  process.stdout.write = ((chunk: string | Uint8Array, ...args: unknown[]) => {
+    if (typeof chunk === 'string') chunk = brandResumeHint(chunk);
+    return previousStdoutWrite.call(process.stdout, chunk, ...args as never[]);
+  }) as typeof process.stdout.write;
 
   try {
     const mode = new InteractiveMode(createToolActivityRuntimeView(runtime), {
@@ -111,6 +123,7 @@ async function runLocalFelanSession(options: RunLocalFelanOptions): Promise<stri
       } else {
         process.env.PI_TELEMETRY = previousPiTelemetry;
       }
+      process.stdout.write = previousStdoutWrite;
     }
   }
 }

--- a/apps/tui/src/cli-main.ts
+++ b/apps/tui/src/cli-main.ts
@@ -1,3 +1,4 @@
+import type { SessionManager } from '@earendil-works/pi-coding-agent';
 import type { RunLocalFelanOptions } from './application.js';
 import { runFelanUpdate } from './update.js';
 import { FELAN_VERSION } from './version.js';
@@ -6,6 +7,8 @@ export interface CliDependencies {
   readonly writeOutput?: (line: string) => void;
   readonly writeError?: (line: string) => void;
   readonly launch?: (options: RunLocalFelanOptions) => Promise<void>;
+  readonly pickSession?: () => Promise<SessionManager | undefined>;
+  readonly openSession?: (sessionId: string, sessionDir?: string) => Promise<SessionManager>;
   readonly update?: () => Promise<number>;
 }
 
@@ -13,6 +16,9 @@ const help = `Usage: felan [options] [message]
 
 Options:
   -c, --continue     Continue the most recent session for this directory
+  -r, --resume       Pick a session to resume
+  --session <id>     Resume a specific session
+  --session-dir <dir> Session directory for --session
   --diagnostics      Print local runtime versions and configuration mode
   update             Update a global npm installation of Felan
   -h, --help         Show this help
@@ -31,11 +37,15 @@ export async function runCli(args: readonly string[], dependencies: CliDependenc
   }
 
   let continueRecent = false;
+  let resume = false;
+  let sessionId: string | undefined;
+  let sessionDir: string | undefined;
   let verbose = false;
   const messageParts: string[] = [];
   let positionalOnly = false;
 
-  for (const argument of args) {
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index]!;
     if (positionalOnly) {
       messageParts.push(argument);
       continue;
@@ -44,6 +54,24 @@ export async function runCli(args: readonly string[], dependencies: CliDependenc
       positionalOnly = true;
     } else if (argument === '-c' || argument === '--continue') {
       continueRecent = true;
+    } else if (argument === '-r' || argument === '--resume') {
+      resume = true;
+    } else if (argument === '--session') {
+      const value = args[index + 1];
+      if (value === undefined || value.startsWith('-')) {
+        writeError('--session requires an id');
+        return 1;
+      }
+      sessionId = value;
+      index += 1;
+    } else if (argument === '--session-dir') {
+      const value = args[index + 1];
+      if (value === undefined || value.startsWith('-')) {
+        writeError('--session-dir requires a directory');
+        return 1;
+      }
+      sessionDir = value;
+      index += 1;
     } else if (argument === '--verbose') {
       verbose = true;
     } else if (argument === '-h' || argument === '--help') {
@@ -72,6 +100,31 @@ export async function runCli(args: readonly string[], dependencies: CliDependenc
     }
   }
 
+  if (continueRecent && (resume || sessionId !== undefined)) {
+    writeError('Cannot combine --continue with --resume or --session');
+    return 1;
+  }
+  if (resume && sessionId !== undefined) {
+    writeError('Cannot combine --resume with --session');
+    return 1;
+  }
+  if (sessionDir !== undefined && sessionId === undefined) {
+    writeError('--session-dir requires --session');
+    return 1;
+  }
+
+  let sessionManager: SessionManager | undefined;
+  if (resume) {
+    const pickSession = dependencies.pickSession
+      ?? (await import('./resume.js')).selectLocalSessionManager;
+    sessionManager = await pickSession();
+    if (!sessionManager) return 0;
+  } else if (sessionId !== undefined) {
+    const openSession = dependencies.openSession
+      ?? (await import('./resume.js')).openLocalSessionManager;
+    sessionManager = await openSession(sessionId, sessionDir);
+  }
+
   const launch = dependencies.launch ?? (async (options: RunLocalFelanOptions) => {
     const { runLocalFelan } = await import('./application.js');
     await runLocalFelan(options);
@@ -79,6 +132,7 @@ export async function runCli(args: readonly string[], dependencies: CliDependenc
   await launch({
     continueRecent,
     verbose,
+    ...(sessionManager === undefined ? {} : { sessionManager }),
     ...(messageParts.length === 0 ? {} : { initialMessage: messageParts.join(' ') }),
   });
   return 0;

--- a/apps/tui/src/index.ts
+++ b/apps/tui/src/index.ts
@@ -1,4 +1,5 @@
 export { runLocalFelan } from './application.js';
+export { openLocalSessionManager, selectLocalSessionManager } from './resume.js';
 export type { RunLocalFelanOptions } from './application.js';
 export { runCli } from './cli-main.js';
 export type { CliDependencies } from './cli-main.js';

--- a/apps/tui/src/resume.ts
+++ b/apps/tui/src/resume.ts
@@ -1,0 +1,40 @@
+import { join } from 'node:path';
+import { SessionManager } from '@earendil-works/pi-coding-agent';
+import { selectLocalSession } from './session-picker.js';
+import { getLocalAgentDir } from './runtime.js';
+import { createLocalSettingsManager } from './settings.js';
+
+export async function selectLocalSessionManager(): Promise<SessionManager | undefined> {
+  const cwd = process.cwd();
+  const agentDir = getLocalAgentDir();
+  const settings = createLocalSettingsManager(cwd, agentDir);
+  const sessionDir = settings.getSessionDir() ?? join(agentDir, 'sessions');
+  const [currentSessions, allSessions] = await Promise.all([
+    SessionManager.list(cwd, sessionDir),
+    SessionManager.listAll(sessionDir),
+  ]);
+  const path = await selectLocalSession({
+    currentSessions,
+    allSessions,
+    agentDir,
+    showHardwareCursor: settings.getShowHardwareCursor(),
+    clearOnShrink: settings.getClearOnShrink(),
+  });
+  return path ? SessionManager.open(path, sessionDir) : undefined;
+}
+
+export async function openLocalSessionManager(
+  sessionId: string,
+  sessionDirOverride?: string,
+): Promise<SessionManager> {
+  const cwd = process.cwd();
+  const agentDir = getLocalAgentDir();
+  const sessionDir = sessionDirOverride
+    ?? createLocalSettingsManager(cwd, agentDir).getSessionDir()
+    ?? join(agentDir, 'sessions');
+  const sessions = await SessionManager.listAll(sessionDir);
+  const session = sessions.find(({ id }) => id === sessionId)
+    ?? sessions.find(({ id }) => id.startsWith(sessionId));
+  if (!session) throw new Error(`No session found matching '${sessionId}'`);
+  return SessionManager.open(session.path, sessionDir);
+}

--- a/apps/tui/src/session-picker.ts
+++ b/apps/tui/src/session-picker.ts
@@ -1,0 +1,271 @@
+import { homedir } from 'node:os';
+import {
+  Input,
+  fuzzyMatch,
+  Key,
+  matchesKey,
+  ProcessTerminal,
+  truncateToWidth,
+  TuiMainScreen,
+  type Component,
+  type Focusable,
+  type TUI,
+} from '@earendil-works/pi-tui';
+import type { SessionInfo } from '@earendil-works/pi-coding-agent';
+
+type PickerScope = 'current' | 'all';
+type PickerSort = 'threaded' | 'recent' | 'fuzzy';
+
+export interface SelectLocalSessionOptions {
+  readonly currentSessions: readonly SessionInfo[];
+  readonly allSessions: readonly SessionInfo[];
+  readonly agentDir: string;
+  readonly showHardwareCursor?: boolean;
+  readonly clearOnShrink?: boolean;
+  readonly createTui?: () => TUI;
+}
+
+interface PickerSession {
+  readonly session: SessionInfo;
+  readonly depth: number;
+}
+
+export async function selectLocalSession(
+  options: SelectLocalSessionOptions,
+): Promise<string | undefined> {
+  if (options.allSessions.length === 0) return undefined;
+
+  const ui = options.createTui?.() ?? new TuiMainScreen(
+    new ProcessTerminal(),
+    options.showHardwareCursor,
+    options.agentDir,
+  );
+  if (options.clearOnShrink !== undefined) ui.setClearOnShrink(options.clearOnShrink);
+
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (path: string | undefined) => {
+      if (settled) return;
+      settled = true;
+      ui.stop();
+      resolve(path);
+    };
+    const picker = new LocalSessionPicker(
+      options.currentSessions,
+      options.allSessions,
+      (path) => finish(path),
+      () => finish(undefined),
+      () => ui.requestRender(),
+    );
+    ui.addChild(picker);
+    ui.setFocus(picker);
+    ui.start();
+  });
+}
+
+export class LocalSessionPicker implements Component, Focusable {
+  readonly #currentSessions: readonly SessionInfo[];
+  readonly #allSessions: readonly SessionInfo[];
+  readonly #onSelect: (path: string) => void;
+  readonly #onCancel: () => void;
+  readonly #requestRender: () => void;
+  readonly #searchInput = new Input();
+  #scope: PickerScope = 'current';
+  #sort: PickerSort = 'threaded';
+  #namedOnly = false;
+  #showPath = false;
+  #selectedIndex = 0;
+  #focused = false;
+
+  constructor(
+    currentSessions: readonly SessionInfo[],
+    allSessions: readonly SessionInfo[],
+    onSelect: (path: string) => void,
+    onCancel: () => void,
+    requestRender: () => void = () => {},
+  ) {
+    this.#currentSessions = currentSessions;
+    this.#allSessions = allSessions;
+    this.#onSelect = onSelect;
+    this.#onCancel = onCancel;
+    this.#requestRender = requestRender;
+  }
+
+  get focused(): boolean {
+    return this.#focused;
+  }
+
+  set focused(value: boolean) {
+    this.#focused = value;
+    this.#searchInput.focused = value;
+  }
+
+  invalidate(): void {
+    this.#searchInput.invalidate();
+  }
+
+  render(width: number): string[] {
+    const sessions = this.#visibleSessions();
+    const scope = this.#scope === 'current' ? 'Current Folder' : 'All';
+    const nameFilter = this.#namedOnly ? 'Named' : 'All';
+    const lines = [
+      truncateToWidth(`Resume Session (${scope})  Sort: ${capitalize(this.#sort)}  Name: ${nameFilter}`, width),
+      truncateToWidth('Tab scope  Ctrl+S sort  Ctrl+N named  Ctrl+P path  Enter resume  Esc cancel', width),
+      `Search: ${this.#searchInput.render(Math.max(1, width - 8))[0] ?? ''}`,
+      '',
+    ];
+
+    if (sessions.length === 0) {
+      const message = this.#scope === 'current'
+        ? 'No sessions in current folder. Press Tab to view all.'
+        : 'No sessions found.';
+      lines.push(truncateToWidth(message, width));
+      return lines;
+    }
+
+    this.#selectedIndex = Math.max(0, Math.min(this.#selectedIndex, sessions.length - 1));
+    const first = Math.max(0, Math.min(this.#selectedIndex - 4, sessions.length - 10));
+    for (const [index, item] of sessions.slice(first, first + 10).entries()) {
+      const absoluteIndex = first + index;
+      const session = item.session;
+      const label = cleanText(session.name ?? session.firstMessage) || session.id;
+      const treePrefix = item.depth === 0 ? '' : `${'  '.repeat(item.depth - 1)}└─ `;
+      const metadata = [
+        this.#showPath ? shortenPath(session.path) : undefined,
+        this.#scope === 'all' ? shortenPath(session.cwd) : undefined,
+        `${session.messageCount} messages`,
+        formatAge(session.modified),
+      ].filter((value): value is string => Boolean(value)).join(' · ');
+      const marker = absoluteIndex === this.#selectedIndex ? '> ' : '  ';
+      lines.push(truncateToWidth(`${marker}${treePrefix}${label}  ${metadata}`, width));
+    }
+
+    if (sessions.length > 10) {
+      lines.push(`(${this.#selectedIndex + 1}/${sessions.length})`);
+    }
+    return lines;
+  }
+
+  handleInput(data: string): void {
+    if (matchesKey(data, Key.tab)) {
+      this.#scope = this.#scope === 'current' ? 'all' : 'current';
+      this.#selectedIndex = 0;
+    } else if (matchesKey(data, Key.ctrl('s'))) {
+      this.#sort = this.#sort === 'threaded' ? 'recent' : this.#sort === 'recent' ? 'fuzzy' : 'threaded';
+      this.#selectedIndex = 0;
+    } else if (matchesKey(data, Key.ctrl('n'))) {
+      this.#namedOnly = !this.#namedOnly;
+      this.#selectedIndex = 0;
+    } else if (matchesKey(data, Key.ctrl('p'))) {
+      this.#showPath = !this.#showPath;
+    } else if (matchesKey(data, Key.up)) {
+      this.#selectedIndex = Math.max(0, this.#selectedIndex - 1);
+    } else if (matchesKey(data, Key.down)) {
+      this.#selectedIndex = Math.max(
+        0,
+        Math.min(this.#visibleSessions().length - 1, this.#selectedIndex + 1),
+      );
+    } else if (matchesKey(data, Key.pageUp)) {
+      this.#selectedIndex = Math.max(0, this.#selectedIndex - 10);
+    } else if (matchesKey(data, Key.pageDown)) {
+      this.#selectedIndex = Math.max(
+        0,
+        Math.min(this.#visibleSessions().length - 1, this.#selectedIndex + 10),
+      );
+    } else if (matchesKey(data, Key.enter)) {
+      const selected = this.#visibleSessions()[this.#selectedIndex];
+      if (selected) this.#onSelect(selected.session.path);
+    } else if (matchesKey(data, Key.escape)) {
+      this.#onCancel();
+    } else {
+      this.#searchInput.handleInput(data);
+      this.#selectedIndex = 0;
+    }
+    this.#requestRender();
+  }
+
+  #visibleSessions(): PickerSession[] {
+    const sessions = this.#scope === 'current' ? this.#currentSessions : this.#allSessions;
+    const named = this.#namedOnly ? sessions.filter((session) => Boolean(session.name?.trim())) : sessions;
+    const query = this.#searchInput.getValue().trim();
+    const matched = query.length === 0
+      ? [...named]
+      : named.filter((session) => fuzzyMatch(query.toLowerCase(), sessionSearchText(session)).matches);
+
+    if (this.#sort === 'threaded' && query.length === 0) return threadSessions(matched);
+    if (this.#sort === 'recent') {
+      return matched
+        .sort((left, right) => right.modified.getTime() - left.modified.getTime())
+        .map((session) => ({ session, depth: 0 }));
+    }
+    return matched
+      .map((session) => ({ session, score: fuzzyScore(sessionSearchText(session), query.toLowerCase()) }))
+      .sort((left, right) => left.score - right.score || right.session.modified.getTime() - left.session.modified.getTime())
+      .map(({ session }) => ({ session, depth: 0 }));
+  }
+}
+
+function sessionSearchText(session: SessionInfo): string {
+  return `${session.id} ${session.name ?? ''} ${session.allMessagesText} ${session.cwd}`.toLowerCase();
+}
+
+function fuzzyScore(text: string, query: string): number {
+  if (query.length === 0) return 0;
+  let score = 0;
+  let cursor = 0;
+  for (const character of query) {
+    const match = text.indexOf(character, cursor);
+    if (match === -1) return Number.POSITIVE_INFINITY;
+    score += match - cursor;
+    cursor = match + 1;
+  }
+  return score;
+}
+
+function threadSessions(sessions: readonly SessionInfo[]): PickerSession[] {
+  const children = new Map<string, SessionInfo[]>();
+  const paths = new Set(sessions.map((session) => session.path));
+  const roots: SessionInfo[] = [];
+  for (const session of sessions) {
+    const parent = session.parentSessionPath;
+    if (!parent || !paths.has(parent)) {
+      roots.push(session);
+      continue;
+    }
+    children.set(parent, [...(children.get(parent) ?? []), session]);
+  }
+  const byRecent = (left: SessionInfo, right: SessionInfo) => right.modified.getTime() - left.modified.getTime();
+  const result: PickerSession[] = [];
+  const visit = (session: SessionInfo, depth: number) => {
+    result.push({ session, depth });
+    for (const child of (children.get(session.path) ?? []).sort(byRecent)) visit(child, depth + 1);
+  };
+  for (const root of roots.sort(byRecent)) visit(root, 0);
+  return result;
+}
+
+function cleanText(value: string): string {
+  return value.replace(/[\x00-\x1f\x7f]/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+function shortenPath(path: string): string {
+  const home = homedir();
+  return path.startsWith(home) ? `~${path.slice(home.length)}` : path;
+}
+
+function formatAge(modified: Date): string {
+  const minutes = Math.max(0, Math.floor((Date.now() - modified.getTime()) / 60_000));
+  if (minutes < 1) return 'now';
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d`;
+  if (days < 30) return `${Math.floor(days / 7)}w`;
+  if (days < 365) return `${Math.floor(days / 30)}mo`;
+  return `${Math.floor(days / 365)}y`;
+}
+
+function capitalize(value: string): string {
+  return `${value[0]?.toUpperCase() ?? ''}${value.slice(1)}`;
+}

--- a/apps/tui/test/application.test.ts
+++ b/apps/tui/test/application.test.ts
@@ -131,7 +131,7 @@ vi.mock('../src/update.js', async (importOriginal) => {
   };
 });
 
-import { runLocalFelan } from '../src/application.js';
+import { brandResumeHint, runLocalFelan } from '../src/application.js';
 import { CwdChangeRequested } from '../src/cwd-command.js';
 
 const temporaryPaths: string[] = [];
@@ -161,6 +161,20 @@ afterEach(async () => {
 });
 
 describe('interactive application', () => {
+  it('brands Pi resume hints as runnable Felan commands', () => {
+    expect(brandResumeHint(
+      "To resume this session: pi --session-dir 'C:\\Users\\35988\\.felan\\sessions' --session 01a033a6-db3c-7094-993f-0aad3b3dadfd\n",
+    )).toBe(
+      "To resume this session: felan --session-dir 'C:\\Users\\35988\\.felan\\sessions' --session 01a033a6-db3c-7094-993f-0aad3b3dadfd\n",
+    );
+    expect(brandResumeHint('ordinary output\n')).toBe('ordinary output\n');
+    expect(brandResumeHint(
+      '\x1b[2mTo resume this session:\x1b[22m pi --session session-id\n',
+    )).toBe(
+      '\x1b[2mTo resume this session:\x1b[22m felan --session session-id\n',
+    );
+  });
+
   it('runs Pi InteractiveMode with the composed local Agent Core runtime', async () => {
     const root = await temporaryDirectory();
     const cwd = join(root, 'workspace');
@@ -168,6 +182,7 @@ describe('interactive application', () => {
     const previousPiAgentDir = process.env.PI_CODING_AGENT_DIR;
     const previousPiSkipVersionCheck = process.env.PI_SKIP_VERSION_CHECK;
     const previousPiTelemetry = process.env.PI_TELEMETRY;
+    const previousStdoutWrite = process.stdout.write;
     await mkdir(cwd, { recursive: true });
 
     await runLocalFelan({ cwd, agentDir });
@@ -183,6 +198,7 @@ describe('interactive application', () => {
     expect(process.env.PI_CODING_AGENT_DIR).toBe(previousPiAgentDir);
     expect(process.env.PI_SKIP_VERSION_CHECK).toBe(previousPiSkipVersionCheck);
     expect(process.env.PI_TELEMETRY).toBe(previousPiTelemetry);
+    expect(process.stdout.write).toBe(previousStdoutWrite);
     expect(interactive.toolNames).toEqual(expect.arrayContaining([
       'read',
       'bash',

--- a/apps/tui/test/cli.test.ts
+++ b/apps/tui/test/cli.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import { AGENT_CORE_VERSION } from '@felan-ai/agent-core';
+import { SessionManager } from '@earendil-works/pi-coding-agent';
 import { runCli } from '../src/cli-main.js';
 import { FELAN_VERSION } from '../src/version.js';
+import type { RunLocalFelanOptions } from '../src/application.js';
 
 describe('felan CLI', () => {
   it('runs update without starting the interactive application', async () => {
@@ -97,6 +99,97 @@ describe('felan CLI', () => {
       verbose: true,
       initialMessage: 'inspect this project',
     }]);
+  });
+
+  it('opens the session picker for both resume aliases', async () => {
+    for (const argument of ['-r', '--resume']) {
+      const sessionManager = SessionManager.inMemory('/stored/project');
+      const launches: RunLocalFelanOptions[] = [];
+
+      const exitCode = await runCli([argument], {
+        pickSession: async () => sessionManager,
+        launch: async (options) => launches.push(options),
+      });
+
+      expect(exitCode).toBe(0);
+      expect(launches).toEqual([{
+        continueRecent: false,
+        verbose: false,
+        sessionManager,
+      }]);
+    }
+  });
+
+  it('exits without launching when session selection is cancelled', async () => {
+    let launched = false;
+
+    const exitCode = await runCli(['--resume'], {
+      pickSession: async () => undefined,
+      launch: async () => { launched = true; },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(launched).toBe(false);
+  });
+
+  it('opens a specific session with its optional directory', async () => {
+    const sessionManager = SessionManager.inMemory('/stored/project');
+    const opened: unknown[] = [];
+    const launches: RunLocalFelanOptions[] = [];
+
+    const exitCode = await runCli([
+      '--session-dir', 'C:\\Users\\35988\\.felan\\sessions',
+      '--session', '01a033a6-db3c-7094-993f-0aad3b3dadfd',
+    ], {
+      openSession: async (id, sessionDir) => {
+        opened.push({ id, sessionDir });
+        return sessionManager;
+      },
+      launch: async (options) => launches.push(options),
+    });
+
+    expect(exitCode).toBe(0);
+    expect(opened).toEqual([{
+      id: '01a033a6-db3c-7094-993f-0aad3b3dadfd',
+      sessionDir: 'C:\\Users\\35988\\.felan\\sessions',
+    }]);
+    expect(launches[0]?.sessionManager).toBe(sessionManager);
+  });
+
+  it('rejects conflicting resume flags before selection or launch', async () => {
+    const errors: string[] = [];
+    let picked = false;
+    let launched = false;
+
+    const exitCode = await runCli(['--continue', '--resume'], {
+      writeError: (line) => errors.push(line),
+      pickSession: async () => {
+        picked = true;
+        return undefined;
+      },
+      launch: async () => { launched = true; },
+    });
+
+    expect(exitCode).toBe(1);
+    expect(errors).toEqual(['Cannot combine --continue with --resume or --session']);
+    expect(picked).toBe(false);
+    expect(launched).toBe(false);
+  });
+
+  it('does not consume another option as a session argument', async () => {
+    const errors: string[] = [];
+
+    expect(await runCli(['--session', '--continue'], {
+      writeError: (line) => errors.push(line),
+    })).toBe(1);
+    expect(await runCli(['--session-dir', '--help'], {
+      writeError: (line) => errors.push(line),
+    })).toBe(1);
+
+    expect(errors).toEqual([
+      '--session requires an id',
+      '--session-dir requires a directory',
+    ]);
   });
 
   it('rejects unknown options before starting the TUI', async () => {

--- a/apps/tui/test/resume.test.ts
+++ b/apps/tui/test/resume.test.ts
@@ -1,0 +1,66 @@
+import { mkdtemp, mkdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { SessionManager } from '@earendil-works/pi-coding-agent';
+import { openLocalSessionManager } from '../src/resume.js';
+
+const temporaryPaths: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryPaths.splice(0).map((path) => rm(path, { force: true, recursive: true })));
+});
+
+describe('local session resume', () => {
+  it('opens the exact stored session with its original working directory', async () => {
+    const root = await temporaryDirectory();
+    const sessionDir = join(root, 'sessions');
+    const storedCwd = join(root, 'stored-project');
+    await Promise.all([sessionDir, storedCwd].map((path) => mkdir(path, { recursive: true })));
+    const stored = SessionManager.create(storedCwd, sessionDir);
+    stored.appendMessage({
+      role: 'user',
+      content: [{ type: 'text', text: 'resume me' }],
+      timestamp: Date.now(),
+    });
+    stored.appendMessage({
+      role: 'assistant',
+      content: [{ type: 'text', text: 'ready' }],
+      api: 'anthropic-messages',
+      provider: 'anthropic',
+      model: 'test-model',
+      usage: {
+        input: 1,
+        output: 1,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 2,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: 'stop',
+      timestamp: Date.now(),
+    });
+
+    const opened = await openLocalSessionManager(stored.getSessionId(), sessionDir);
+
+    expect(opened.getSessionId()).toBe(stored.getSessionId());
+    expect(opened.getCwd()).toBe(storedCwd);
+    expect(opened.getSessionFile()).toBe(stored.getSessionFile());
+  });
+
+  it('rejects an unknown session id', async () => {
+    const root = await temporaryDirectory();
+    const sessionDir = join(root, 'sessions');
+    await mkdir(sessionDir, { recursive: true });
+
+    await expect(openLocalSessionManager('missing', sessionDir)).rejects.toThrow(
+      "No session found matching 'missing'",
+    );
+  });
+});
+
+async function temporaryDirectory(): Promise<string> {
+  const path = await mkdtemp(join(tmpdir(), 'felan-tui-resume-'));
+  temporaryPaths.push(path);
+  return path;
+}

--- a/apps/tui/test/session-picker.test.ts
+++ b/apps/tui/test/session-picker.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { SessionInfo } from '@earendil-works/pi-coding-agent';
+import { Key, type Component, type TUI } from '@earendil-works/pi-tui';
+import { LocalSessionPicker, selectLocalSession } from '../src/session-picker.js';
+
+describe('local session picker', () => {
+  it('shows current sessions and identifying metadata without mutation actions', () => {
+    const picker = createPicker([
+      session('current', { name: 'Current task', messageCount: 4 }),
+    ], [
+      session('current', { name: 'Current task', messageCount: 4 }),
+      session('other', { cwd: '/other/project' }),
+    ]);
+
+    const output = picker.render(200).join('\n');
+
+    expect(output).toContain('Resume Session (Current Folder)');
+    expect(output).toContain('Current task');
+    expect(output).toContain('4 messages');
+    expect(output).not.toMatch(/delete|rename/i);
+    expect(output).not.toContain('/other/project');
+  });
+
+  it('switches scope, sort, named filtering, and path display', () => {
+    const named = session('named', { name: 'Named session', cwd: '/other/project' });
+    const unnamed = session('unnamed', { firstMessage: 'Unsorted work', path: '/sessions/unnamed.jsonl' });
+    const picker = createPicker([], [unnamed, named]);
+
+    picker.handleInput(keyData(Key.tab));
+    expect(picker.render(200).join('\n')).toContain('/other/project');
+
+    picker.handleInput(keyData(Key.ctrl('n')));
+    expect(picker.render(200).join('\n')).toContain('Named session');
+    expect(picker.render(200).join('\n')).not.toContain('Unsorted work');
+
+    picker.handleInput(keyData(Key.ctrl('p')));
+    expect(picker.render(200).join('\n')).toContain('/sessions/named.jsonl');
+
+    picker.handleInput(keyData(Key.ctrl('s')));
+    expect(picker.render(200)[0]).toContain('Sort: Recent');
+  });
+
+  it('searches session id, name, messages, and cwd', () => {
+    const candidates = [
+      session('id-match'),
+      session('named', { name: 'Release work' }),
+      session('message', { allMessagesText: 'Investigate database timeout' }),
+      session('cwd', { cwd: '/projects/observability' }),
+    ];
+
+    for (const [query, expected] of [
+      ['id-match', 'id-match'],
+      ['release', 'named'],
+      ['database', 'message'],
+      ['observability', 'cwd'],
+    ]) {
+      const picker = createPicker(candidates, candidates);
+      picker.handleInput(query);
+      const output = picker.render(200).join('\n');
+      expect(output).toContain(expected);
+    }
+  });
+
+  it('renders threaded sessions and selects the highlighted exact path', () => {
+    const selected: string[] = [];
+    const root = session('root');
+    const child = session('child', { parentSessionPath: root.path });
+    const picker = new LocalSessionPicker([root, child], [root, child], (path) => selected.push(path), () => {});
+
+    expect(picker.render(200).join('\n')).toContain('└─ child');
+    picker.handleInput(keyData(Key.down));
+    picker.handleInput(keyData(Key.enter));
+
+    expect(selected).toEqual([child.path]);
+  });
+
+  it('explains an empty current scope and cancels cleanly', () => {
+    let cancelled = false;
+    const picker = new LocalSessionPicker([], [session('other')], () => {}, () => {
+      cancelled = true;
+    });
+
+    expect(picker.render(100).join('\n')).toContain('Press Tab to view all');
+    picker.handleInput(keyData(Key.escape));
+    expect(cancelled).toBe(true);
+  });
+
+  it('does not start a TUI when no local sessions exist', async () => {
+    const createTui = vi.fn();
+
+    await expect(selectLocalSession({
+      currentSessions: [],
+      allSessions: [],
+      agentDir: '/agent',
+      createTui,
+    })).resolves.toBeUndefined();
+    expect(createTui).not.toHaveBeenCalled();
+  });
+
+  it('stops the picker TUI after selection', async () => {
+    const tui = fakeTui();
+    const result = selectLocalSession({
+      currentSessions: [session('selected')],
+      allSessions: [session('selected')],
+      agentDir: '/agent',
+      createTui: () => tui,
+    });
+
+    (tui.children[0] as LocalSessionPicker).handleInput(keyData(Key.enter));
+
+    await expect(result).resolves.toBe('/sessions/selected.jsonl');
+    expect(tui.stop).toHaveBeenCalledOnce();
+  });
+});
+
+function createPicker(current: SessionInfo[], all: SessionInfo[]): LocalSessionPicker {
+  return new LocalSessionPicker(current, all, () => {}, () => {});
+}
+
+function session(id: string, overrides: Partial<SessionInfo> = {}): SessionInfo {
+  return {
+    path: `/sessions/${id}.jsonl`,
+    id,
+    cwd: '/current/project',
+    name: undefined,
+    parentSessionPath: undefined,
+    firstMessage: id,
+    allMessagesText: '',
+    messageCount: 1,
+    created: new Date('2026-08-24T10:00:00Z'),
+    modified: new Date('2026-08-24T11:00:00Z'),
+    ...overrides,
+  };
+}
+
+function keyData(key: string): string {
+  const map: Record<string, string> = {
+    tab: '\t',
+    enter: '\r',
+    escape: '\x1b',
+    down: '\x1b[B',
+    'ctrl+n': '\x0e',
+    'ctrl+p': '\x10',
+    'ctrl+s': '\x13',
+  };
+  const data = map[key];
+  if (!data) throw new Error(`Missing test key data for ${key}`);
+  return data;
+}
+
+function fakeTui(): TUI {
+  const children: Component[] = [];
+  return {
+    mode: 'regular',
+    children,
+    terminal: {} as TUI['terminal'],
+    fullRedraws: 0,
+    addChild: (child) => children.push(child),
+    removeChild: () => {},
+    clear: () => {},
+    getShowHardwareCursor: () => false,
+    setShowHardwareCursor: () => {},
+    getClearOnShrink: () => true,
+    setClearOnShrink: () => {},
+    setFocus: (component) => {
+      if (component && 'focused' in component) (component as Component & { focused: boolean }).focused = true;
+    },
+    showOverlay: () => { throw new Error('not used'); },
+    hideOverlay: () => {},
+    hasOverlay: () => false,
+    start: vi.fn(),
+    stop: vi.fn(),
+    renderNow: () => {},
+    requestRender: () => {},
+    addInputListener: () => () => {},
+    removeInputListener: () => {},
+    onTerminalColorSchemeChange: () => () => {},
+    setTerminalColorSchemeNotifications: () => {},
+    queryTerminalBackgroundColor: async () => undefined,
+    queryTerminalColorScheme: async () => undefined,
+    invalidate: () => {},
+    render: () => [],
+  };
+}

--- a/docs/user-guide/local-cli.md
+++ b/docs/user-guide/local-cli.md
@@ -10,6 +10,9 @@ and TUI presentation.
 felan [options] [message]
 
 -c, --continue     Continue the most recent session for this directory
+-r, --resume       Pick a session to resume
+--session <id>     Resume a specific session
+--session-dir <dir> Session directory for --session
 --diagnostics      Print runtime versions and configuration mode
 update             Update a global npm installation of Felan
 -h, --help         Show help
@@ -19,6 +22,14 @@ update             Update a global npm installation of Felan
 
 Use `--` before an initial message that begins with a dash. Unknown options are
 rejected before the TUI starts.
+
+### Resume a session
+
+`felan --resume` opens a selection-only picker. Use Tab to switch between the
+current folder and all local sessions, Ctrl+S to change sorting, Ctrl+N to show
+only named sessions, and Ctrl+P to toggle session-file paths. Escape cancels
+without creating or launching a session. `felan --continue` remains the quick
+path for the most recent session in the current directory.
 
 ### Update Felan
 

--- a/scripts/test-packed-bin.mjs
+++ b/scripts/test-packed-bin.mjs
@@ -425,7 +425,11 @@ try {
     }
   }
   const help = runFelan(['--help'], cleanEnvironment);
-  if (!help.stdout.includes('Usage: felan [options] [message]') || !help.stdout.includes('update')) {
+  if (
+    !help.stdout.includes('Usage: felan [options] [message]')
+    || !help.stdout.includes('-r, --resume')
+    || !help.stdout.includes('update')
+  ) {
     throw new Error('Packed felan --help did not start the local TUI CLI');
   }
   const update = runFelanAllowFailure(['update'], cleanEnvironment);


### PR DESCRIPTION
## Summary

- add `felan -r` / `felan --resume` with a selection-only local session picker
- support current/all scopes, search, sorting, named filtering, and optional path display
- restore the selected session and its original working directory through Felan's normal runtime
- add direct `--session` / `--session-dir` handling so shutdown hints are runnable
- replace Pi-branded shutdown resume hints with Felan commands

## Verification

- `pnpm --filter @felan-ai/felan type-check`
- 33 focused TUI tests passed, including `/cwd` integration
- `pnpm --filter @felan-ai/felan build`
- `pnpm check:proposed-version` confirms `@felan-ai/felan@0.13.9` is available
