### PR TITLE
fix(codebase-memory): validate auto-index target path

### DIFF
--- a/apps/tui/package.json
+++ b/apps/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felan-ai/felan",
-  "version": "0.21.5",
+  "version": "0.21.6",
   "description": "Open-source, model-portable coding agent built for cost-efficient, verifiable software work",
   "keywords": [
     "ai",

--- a/packages/ext-codebase-memory/package.json
+++ b/packages/ext-codebase-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felan-ai/ext-codebase-memory",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Portable Codebase Memory tools and grep augmentation for Felan",
   "license": "MIT",
   "type": "module",

--- a/packages/ext-codebase-memory/src/auto-index-paths.ts
+++ b/packages/ext-codebase-memory/src/auto-index-paths.ts
@@ -3,15 +3,17 @@ export type AutoIndexPathValidation =
   | { ok: false; reason: string };
 
 const SYSTEM_PATHS = new Set([
-  '/Applications', '/Library', '/Network', '/System', '/Users', '/Volumes',
-  '/bin', '/boot', '/cores', '/dev', '/etc', '/home', '/lib', '/lib64',
-  '/media', '/mnt', '/opt', '/private', '/proc', '/root', '/run', '/sbin',
-  '/sys', '/tmp', '/usr', '/var',
+  '/applications', '/bin', '/boot', '/cores', '/dev', '/etc', '/home',
+  '/lib', '/lib64', '/library', '/media', '/mnt', '/network', '/opt',
+  '/perflogs', '/private', '/proc', '/program files', '/program files (x86)',
+  '/programdata', '/recovery', '/root', '/run', '/sbin', '/sys', '/system',
+  '/system volume information', '/tmp', '/usr', '/users', '/var', '/volumes',
+  '/windows',
 ]);
 
 const HOME_BUILTIN_DIRECTORIES = new Set([
-  '.Trash', 'Applications', 'Desktop', 'Documents', 'Downloads',
-  'Library', 'Movies', 'Music', 'Pictures', 'Public',
+  '.trash', 'applications', 'desktop', 'documents', 'downloads',
+  'library', 'movies', 'music', 'pictures', 'public',
 ]);
 
 export function validateAutoIndexPath(path: string): AutoIndexPathValidation {
@@ -21,25 +23,28 @@ export function validateAutoIndexPath(path: string): AutoIndexPathValidation {
   if (normalized === '/' || /^[A-Za-z]:[/\\]?$/u.test(normalized)) {
     return { ok: false, reason: 'refusing to auto-index filesystem root' };
   }
-  if (SYSTEM_PATHS.has(normalized)) {
+
+  const pathWithoutDrive = normalized.replace(/^[A-Za-z]:/u, '');
+
+  if (SYSTEM_PATHS.has(pathWithoutDrive.toLowerCase())) {
     return { ok: false, reason: `refusing to auto-index system directory: ${normalized}` };
   }
-  if (isHomeDirectory(normalized)) {
+  if (isHomeDirectory(pathWithoutDrive)) {
     return { ok: false, reason: 'refusing to auto-index home directory' };
   }
-  if (isHomeBuiltinDirectory(normalized)) {
+  if (isHomeBuiltinDirectory(pathWithoutDrive)) {
     return { ok: false, reason: 'refusing to auto-index builtin user directory' };
   }
   return { ok: true, path: normalized };
 }
 
 function isHomeDirectory(path: string): boolean {
-  return /^\/(?:Users|home)\/[^/]+$/u.test(path);
+  return /^\/(?:Users|home)\/[^/]+$/iu.test(path);
 }
 
 function isHomeBuiltinDirectory(path: string): boolean {
-  const match = /^\/(?:Users|home)\/[^/]+\/([^/]+)$/u.exec(path);
-  return match ? HOME_BUILTIN_DIRECTORIES.has(match[1]!) : false;
+  const match = /^\/(?:Users|home)\/[^/]+\/([^/]+)$/iu.exec(path);
+  return match ? HOME_BUILTIN_DIRECTORIES.has(match[1]!.toLowerCase()) : false;
 }
 
 function normalizePath(path: string): string {

--- a/packages/ext-codebase-memory/src/auto-index-paths.ts
+++ b/packages/ext-codebase-memory/src/auto-index-paths.ts
@@ -1,0 +1,49 @@
+export type AutoIndexPathValidation =
+  | { ok: true; path: string }
+  | { ok: false; reason: string };
+
+const SYSTEM_PATHS = new Set([
+  '/Applications', '/Library', '/Network', '/System', '/Users', '/Volumes',
+  '/bin', '/boot', '/cores', '/dev', '/etc', '/home', '/lib', '/lib64',
+  '/media', '/mnt', '/opt', '/private', '/proc', '/root', '/run', '/sbin',
+  '/sys', '/tmp', '/usr', '/var',
+]);
+
+const HOME_BUILTIN_DIRECTORIES = new Set([
+  '.Trash', 'Applications', 'Desktop', 'Documents', 'Downloads',
+  'Library', 'Movies', 'Music', 'Pictures', 'Public',
+]);
+
+export function validateAutoIndexPath(path: string): AutoIndexPathValidation {
+  const normalized = normalizePath(path);
+  if (!normalized) return { ok: false, reason: 'path is empty' };
+
+  if (normalized === '/' || /^[A-Za-z]:[/\\]?$/u.test(normalized)) {
+    return { ok: false, reason: 'refusing to auto-index filesystem root' };
+  }
+  if (SYSTEM_PATHS.has(normalized)) {
+    return { ok: false, reason: `refusing to auto-index system directory: ${normalized}` };
+  }
+  if (isHomeDirectory(normalized)) {
+    return { ok: false, reason: 'refusing to auto-index home directory' };
+  }
+  if (isHomeBuiltinDirectory(normalized)) {
+    return { ok: false, reason: 'refusing to auto-index builtin user directory' };
+  }
+  return { ok: true, path: normalized };
+}
+
+function isHomeDirectory(path: string): boolean {
+  return /^\/(?:Users|home)\/[^/]+$/u.test(path);
+}
+
+function isHomeBuiltinDirectory(path: string): boolean {
+  const match = /^\/(?:Users|home)\/[^/]+\/([^/]+)$/u.exec(path);
+  return match ? HOME_BUILTIN_DIRECTORIES.has(match[1]!) : false;
+}
+
+function normalizePath(path: string): string {
+  if (!path) return '';
+  const normalized = path.replace(/\\/g, '/').replace(/\/+$/, '');
+  return normalized || '/';
+}

--- a/packages/ext-codebase-memory/src/grep-augmentation.ts
+++ b/packages/ext-codebase-memory/src/grep-augmentation.ts
@@ -26,6 +26,8 @@ export function registerGrepAugmentation(
     if (event.isError) return undefined;
     const startedAt = Date.now();
     try {
+      const rejection = await projects.autoIndexRejectionReason(undefined, remainingMs(startedAt));
+      if (rejection) return undefined;
       const project = await projects.project(undefined, remainingMs(startedAt));
       const result = await client.call('search_code', {
         project,

--- a/packages/ext-codebase-memory/src/index.ts
+++ b/packages/ext-codebase-memory/src/index.ts
@@ -8,7 +8,7 @@ import { acquireCbmClient, detectCbm, type CbmClientLease, type CbmDetection } f
 import { CODEBASE_MEMORY_CONFIG } from './config.js';
 import { registerGrepAugmentation } from './grep-augmentation.js';
 import { installManagedCbm } from './installer.js';
-import { ProjectService, SymbolService } from './services.js';
+import { ProjectService, SymbolService, type IndexResult } from './services.js';
 import { registerTools } from './tools.js';
 
 export const CODEBASE_MEMORY_CAPABILITY_INSTRUCTIONS = `Use Codebase Memory for structural code exploration before broad raw searches: read_symbol reads a known symbol, search_and_read_symbols finds and reads likely implementations, search_code searches indexed text, and codebase_memory proxies other structural queries or refreshes with {command:"index_repository"}. A background index starts at session startup through a lazy root-session MCP frontend shared with subagents and refreshes only when the model calls index_repository or the user invokes /codebase-memory. It may be stale after edits. Direct reads, grep, compiler output, and tests remain authoritative; grep output can include bounded Codebase Memory augmentation. Keep symbol reads focused and at no more than 220 lines per symbol.`;
@@ -130,8 +130,9 @@ async function refresh(projects: ProjectService, ctx: ExtensionContext, session?
   }
   let failed = false;
   let failure: unknown;
+  let result: IndexResult | undefined;
   try {
-    await projects.index(signal);
+    result = await projects.index(signal);
   } catch (error) {
     failed = true;
     failure = error;
@@ -139,6 +140,15 @@ async function refresh(projects: ProjectService, ctx: ExtensionContext, session?
   if (session && !session.active) return;
   try {
     ctx.ui.setStatus('codebase-memory', undefined);
+    if (result?.status === 'skipped') {
+      if (ctx.hasUI) {
+        ctx.ui.notify(
+          `Codebase Memory: ${result.reason} — skipped auto-indexing. Launch Felan from inside a git repo, or index a specific path via codebase_memory({command: "index_repository", arguments: {repo_path: "/path/to/repo"}}).`,
+          'info',
+        );
+      }
+      return;
+    }
     if (failed && ctx.hasUI) {
       ctx.ui.notify(`Codebase Memory index failed: ${failure instanceof Error ? failure.message : String(failure)}`, 'warning');
     }

--- a/packages/ext-codebase-memory/src/index.ts
+++ b/packages/ext-codebase-memory/src/index.ts
@@ -143,7 +143,7 @@ async function refresh(projects: ProjectService, ctx: ExtensionContext, session?
     if (result?.status === 'skipped') {
       if (ctx.hasUI) {
         ctx.ui.notify(
-          `Codebase Memory: ${result.reason} — skipped auto-indexing. Launch Felan from inside a git repo, or index a specific path via codebase_memory({command: "index_repository", arguments: {repo_path: "/path/to/repo"}}).`,
+          `Codebase Memory: ${result.reason} — skipped auto-indexing. Launch Felan from inside a project directory, or index a specific path via codebase_memory({command: "index_repository", arguments: {repo_path: "/path/to/repo"}}).`,
           'info',
         );
       }

--- a/packages/ext-codebase-memory/src/index.ts
+++ b/packages/ext-codebase-memory/src/index.ts
@@ -143,8 +143,8 @@ async function refresh(projects: ProjectService, ctx: ExtensionContext, session?
     if (result?.status === 'skipped') {
       if (ctx.hasUI) {
         ctx.ui.notify(
-          `Codebase Memory: ${result.reason} — skipped auto-indexing. Launch Felan from inside a project directory, or index a specific path via codebase_memory({command: "index_repository", arguments: {repo_path: "/path/to/repo"}}).`,
-          'info',
+          `Codebase Memory: ${result.reason} — skipped auto-indexing. Launch Felan from inside a project directory, or ask the agent to index it explicitly.`,
+          'warning',
         );
       }
       return;

--- a/packages/ext-codebase-memory/src/services.ts
+++ b/packages/ext-codebase-memory/src/services.ts
@@ -1,9 +1,14 @@
 import type { AgentRuntime } from '@felan-ai/agent-core';
+import { validateAutoIndexPath } from './auto-index-paths.js';
 import { CacheManager, type CodebaseMemoryTelemetry } from './cache.js';
 import { CbmClient, INDEX_TIMEOUT_MS } from './client.js';
 
-const activeIndexes = new WeakMap<CbmClient, Map<string, Promise<unknown>>>();
+const activeIndexes = new WeakMap<CbmClient, Map<string, Promise<IndexResult>>>();
 const cacheAccounts = new Map<string, Promise<void>>();
+
+export type IndexResult =
+  | { status: 'indexed'; data: unknown }
+  | { status: 'skipped'; reason: string };
 
 export class ProjectService {
   readonly #cache: CacheManager;
@@ -20,18 +25,26 @@ export class ProjectService {
     });
   }
 
-  async gitRoot(signal?: AbortSignal, timeout = 10_000): Promise<string> {
+  async gitRoot(signal?: AbortSignal, timeout = 10_000): Promise<string | undefined> {
     const result = await this.runtime.exec('git', ['rev-parse', '--show-toplevel'], {
       cwd: this.runtime.cwd,
       maxOutputBytes: 64 * 1024,
       ...(signal === undefined ? {} : { signal }),
       timeout,
     });
-    return result.code === 0 && !result.killed ? result.stdout.trim() || this.runtime.cwd : this.runtime.cwd;
+    if (result.code !== 0 || result.killed) return undefined;
+    return result.stdout.trim() || undefined;
   }
 
-  async index(signal?: AbortSignal): Promise<unknown> {
-    const root = await this.gitRoot(signal);
+  async index(signal?: AbortSignal, repoPath?: string): Promise<IndexResult> {
+    const root = repoPath ?? await this.gitRoot(signal);
+    if (!root) {
+      return { status: 'skipped', reason: 'no git repository detected at current directory' };
+    }
+    if (repoPath === undefined) {
+      const validation = validateAutoIndexPath(root);
+      if (!validation.ok) return { status: 'skipped', reason: validation.reason };
+    }
     let clientIndexes = activeIndexes.get(this.client);
     if (!clientIndexes) {
       clientIndexes = new Map();
@@ -42,13 +55,13 @@ export class ProjectService {
     const request = this.client.call('index_repository', { repo_path: root, mode: 'full' }, {
       ...(signal === undefined ? {} : { signal }),
       timeoutMs: INDEX_TIMEOUT_MS,
-    }).then(async ({ data }) => {
+    }).then(async ({ data }): Promise<IndexResult> => {
       const record = asRecord(data);
       const project = typeof record.project === 'string' ? record.project : projectName(root);
       this.#project = project;
       await this.#cache.record(project, 0);
       void this.#accountCache();
-      return data;
+      return { status: 'indexed', data };
     }).finally(() => {
       if (clientIndexes.get(root) === request) clientIndexes.delete(root);
     });
@@ -84,7 +97,7 @@ export class ProjectService {
 
   async project(signal?: AbortSignal, timeoutMs?: number): Promise<string> {
     if (this.#project) return this.#project;
-    const root = await this.gitRoot(signal, timeoutMs);
+    const root = (await this.gitRoot(signal, timeoutMs)) ?? this.runtime.cwd;
     const listed = await this.client.call('list_projects', {}, {
       ...(signal === undefined ? {} : { signal }),
       ...(timeoutMs === undefined ? {} : { timeoutMs }),

--- a/packages/ext-codebase-memory/src/services.ts
+++ b/packages/ext-codebase-memory/src/services.ts
@@ -13,6 +13,7 @@ export type IndexResult =
 export class ProjectService {
   readonly #cache: CacheManager;
   #project: string | undefined;
+  #skipReason: string | undefined;
 
   constructor(
     private readonly runtime: AgentRuntime,
@@ -41,7 +42,10 @@ export class ProjectService {
     const root = targetPath ?? (await this.gitRoot(signal)) ?? this.runtime.cwd;
     if (targetPath === undefined) {
       const validation = validateAutoIndexPath(root);
-      if (!validation.ok) return { status: 'skipped', reason: validation.reason };
+      if (!validation.ok) {
+        this.#skipReason = validation.reason;
+        return { status: 'skipped', reason: validation.reason };
+      }
     }
     let clientIndexes = activeIndexes.get(this.client);
     if (!clientIndexes) {
@@ -57,6 +61,7 @@ export class ProjectService {
       const record = asRecord(data);
       const project = typeof record.project === 'string' ? record.project : projectName(root);
       this.#project = project;
+      this.#skipReason = undefined;
       await this.#cache.record(project, 0);
       void this.#accountCache();
       return { status: 'indexed', data };
@@ -93,6 +98,31 @@ export class ProjectService {
   }
 
 
+  async autoIndexRejectionReason(signal?: AbortSignal, timeoutMs?: number): Promise<string | undefined> {
+    if (this.#project) return undefined;
+    if (this.#skipReason) return this.#skipReason;
+    const root = (await this.gitRoot(signal, timeoutMs)) ?? this.runtime.cwd;
+    const clientIndexes = activeIndexes.get(this.client);
+    const inFlight = clientIndexes?.get(root);
+    if (inFlight) {
+      try {
+        const result = await inFlight;
+        if (result.status === 'skipped') {
+          this.#skipReason = result.reason;
+          return result.reason;
+        }
+      } catch {
+        // Fall through to path validation
+      }
+    }
+    const validation = validateAutoIndexPath(root);
+    if (!validation.ok) {
+      this.#skipReason = validation.reason;
+      return validation.reason;
+    }
+    return undefined;
+  }
+
   async project(signal?: AbortSignal, timeoutMs?: number): Promise<string> {
     if (this.#project) return this.#project;
     const root = (await this.gitRoot(signal, timeoutMs)) ?? this.runtime.cwd;
@@ -111,6 +141,12 @@ export class SymbolService {
   constructor(private readonly client: CbmClient, private readonly projects: ProjectService) {}
 
   async read(params: Record<string, unknown>, signal?: AbortSignal): Promise<unknown> {
+    const rejection = await this.projects.autoIndexRejectionReason(signal);
+    if (rejection) {
+      return {
+        error: `This folder is not auto-indexed due to: ${rejection}. Index it only after explicit user approval/request.`,
+      };
+    }
     const project = await this.projects.project(signal);
     const search = await this.client.call('search_graph', {
       project,
@@ -146,6 +182,12 @@ export class SymbolService {
   }
 
   async searchAndRead(params: Record<string, unknown>, signal?: AbortSignal): Promise<unknown> {
+    const rejection = await this.projects.autoIndexRejectionReason(signal);
+    if (rejection) {
+      return {
+        error: `This folder is not auto-indexed due to: ${rejection}. Index it only after explicit user approval/request.`,
+      };
+    }
     const project = await this.projects.project(signal);
     const search = await this.client.call('search_graph', {
       project,

--- a/packages/ext-codebase-memory/src/services.ts
+++ b/packages/ext-codebase-memory/src/services.ts
@@ -37,11 +37,9 @@ export class ProjectService {
   }
 
   async index(signal?: AbortSignal, repoPath?: string): Promise<IndexResult> {
-    const root = repoPath ?? await this.gitRoot(signal);
-    if (!root) {
-      return { status: 'skipped', reason: 'no git repository detected at current directory' };
-    }
-    if (repoPath === undefined) {
+    const targetPath = typeof repoPath === 'string' && repoPath.trim() ? repoPath.trim() : undefined;
+    const root = targetPath ?? (await this.gitRoot(signal)) ?? this.runtime.cwd;
+    if (targetPath === undefined) {
       const validation = validateAutoIndexPath(root);
       if (!validation.ok) return { status: 'skipped', reason: validation.reason };
     }

--- a/packages/ext-codebase-memory/src/tools.ts
+++ b/packages/ext-codebase-memory/src/tools.ts
@@ -41,7 +41,7 @@ export function registerTools(
         }
         const args = input.arguments ?? {};
         const data = input.command === 'index_repository'
-          ? await projects.index(signal)
+          ? await projects.index(signal, typeof args.repo_path === 'string' ? args.repo_path : undefined)
           : (await client.call(input.command, {
             ...args,
             project: await projects.project(signal),

--- a/packages/ext-codebase-memory/src/tools.ts
+++ b/packages/ext-codebase-memory/src/tools.ts
@@ -40,12 +40,20 @@ export function registerTools(
           throw new Error(`Unsupported Codebase Memory command: ${input.command}`);
         }
         const args = input.arguments ?? {};
-        const data = input.command === 'index_repository'
-          ? await projects.index(signal, typeof args.repo_path === 'string' ? args.repo_path : undefined)
-          : (await client.call(input.command, {
-            ...args,
-            project: await projects.project(signal),
-          }, signal === undefined ? {} : { signal })).data;
+        if (input.command === 'index_repository') {
+          const data = await projects.index(signal, typeof args.repo_path === 'string' ? args.repo_path : undefined);
+          return toolResult(data);
+        }
+        const rejection = await projects.autoIndexRejectionReason(signal);
+        if (rejection) {
+          return toolResult({
+            error: `This folder is not auto-indexed due to: ${rejection}. Index it only after explicit user approval/request.`,
+          });
+        }
+        const data = (await client.call(input.command, {
+          ...args,
+          project: await projects.project(signal),
+        }, signal === undefined ? {} : { signal })).data;
         return toolResult(data);
       },
       renderCall(params, theme) {
@@ -119,6 +127,12 @@ export function registerTools(
         max_symbol_lines: MaxSymbolLines,
       }, { additionalProperties: false }),
       execute: async (_id, params, signal) => {
+        const rejection = await projects.autoIndexRejectionReason(signal);
+        if (rejection) {
+          return toolResult({
+            error: `This folder is not auto-indexed due to: ${rejection}. Index it only after explicit user approval/request.`,
+          });
+        }
         const input = params as Record<string, unknown>;
         const project = await projects.project(signal);
         return toolResult((await client.call('search_code', { ...input, project }, signal === undefined ? {} : { signal })).data);

--- a/packages/ext-codebase-memory/test/auto-index-paths.test.ts
+++ b/packages/ext-codebase-memory/test/auto-index-paths.test.ts
@@ -7,15 +7,24 @@ describe('validateAutoIndexPath', () => {
       ok: true,
       path: '/Users/alice/Projects/felan',
     });
+    expect(validateAutoIndexPath('C:\\Users\\alice\\Projects\\felan')).toEqual({
+      ok: true,
+      path: 'C:/Users/alice/Projects/felan',
+    });
   });
 
   it('rejects filesystem roots', () => {
     expect(validateAutoIndexPath('/')).toEqual({ ok: false, reason: expect.stringContaining('filesystem root') });
     expect(validateAutoIndexPath('C:\\')).toEqual({ ok: false, reason: expect.stringContaining('filesystem root') });
+    expect(validateAutoIndexPath('C:/')).toEqual({ ok: false, reason: expect.stringContaining('filesystem root') });
+    expect(validateAutoIndexPath('d:')).toEqual({ ok: false, reason: expect.stringContaining('filesystem root') });
   });
 
   it('rejects known system directories', () => {
-    for (const path of ['/System', '/usr', '/etc', '/var', '/Library', '/private', '/tmp', '/opt']) {
+    for (const path of [
+      '/System', '/usr', '/etc', '/var', '/Library', '/private', '/tmp', '/opt',
+      'C:\\Windows', 'c:\\windows\\', 'C:\\Program Files', 'C:\\Program Files (x86)', 'C:\\Users',
+    ]) {
       expect(validateAutoIndexPath(path)).toEqual({ ok: false, reason: expect.stringContaining('system directory') });
     }
   });
@@ -23,6 +32,8 @@ describe('validateAutoIndexPath', () => {
   it('rejects the home directory itself', () => {
     expect(validateAutoIndexPath('/Users/alice')).toEqual({ ok: false, reason: 'refusing to auto-index home directory' });
     expect(validateAutoIndexPath('/home/bob')).toEqual({ ok: false, reason: 'refusing to auto-index home directory' });
+    expect(validateAutoIndexPath('C:\\Users\\alice')).toEqual({ ok: false, reason: 'refusing to auto-index home directory' });
+    expect(validateAutoIndexPath('c:/users/bob')).toEqual({ ok: false, reason: 'refusing to auto-index home directory' });
   });
 
   it('rejects common home builtin directories', () => {
@@ -31,13 +42,25 @@ describe('validateAutoIndexPath', () => {
         ok: false,
         reason: 'refusing to auto-index builtin user directory',
       });
+      expect(validateAutoIndexPath(`C:\\Users\\alice\\${dir}`)).toEqual({
+        ok: false,
+        reason: 'refusing to auto-index builtin user directory',
+      });
     }
+    expect(validateAutoIndexPath('C:\\Users\\alice\\desktop')).toEqual({
+      ok: false,
+      reason: 'refusing to auto-index builtin user directory',
+    });
   });
 
   it('accepts deeper paths under home', () => {
     expect(validateAutoIndexPath('/Users/alice/code/thing')).toEqual({
       ok: true,
       path: '/Users/alice/code/thing',
+    });
+    expect(validateAutoIndexPath('C:\\Users\\alice\\code\\thing')).toEqual({
+      ok: true,
+      path: 'C:/Users/alice/code/thing',
     });
   });
 
@@ -49,6 +72,10 @@ describe('validateAutoIndexPath', () => {
     expect(validateAutoIndexPath('/Users/alice/Projects/felan/')).toEqual({
       ok: true,
       path: '/Users/alice/Projects/felan',
+    });
+    expect(validateAutoIndexPath('C:\\Users\\alice\\Projects\\felan\\')).toEqual({
+      ok: true,
+      path: 'C:/Users/alice/Projects/felan',
     });
   });
 });

--- a/packages/ext-codebase-memory/test/auto-index-paths.test.ts
+++ b/packages/ext-codebase-memory/test/auto-index-paths.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { validateAutoIndexPath } from '../src/auto-index-paths.js';
+
+describe('validateAutoIndexPath', () => {
+  it('accepts a normal project path', () => {
+    expect(validateAutoIndexPath('/Users/alice/Projects/felan')).toEqual({
+      ok: true,
+      path: '/Users/alice/Projects/felan',
+    });
+  });
+
+  it('rejects filesystem roots', () => {
+    expect(validateAutoIndexPath('/')).toEqual({ ok: false, reason: expect.stringContaining('filesystem root') });
+    expect(validateAutoIndexPath('C:\\')).toEqual({ ok: false, reason: expect.stringContaining('filesystem root') });
+  });
+
+  it('rejects known system directories', () => {
+    for (const path of ['/System', '/usr', '/etc', '/var', '/Library', '/private', '/tmp', '/opt']) {
+      expect(validateAutoIndexPath(path)).toEqual({ ok: false, reason: expect.stringContaining('system directory') });
+    }
+  });
+
+  it('rejects the home directory itself', () => {
+    expect(validateAutoIndexPath('/Users/alice')).toEqual({ ok: false, reason: 'refusing to auto-index home directory' });
+    expect(validateAutoIndexPath('/home/bob')).toEqual({ ok: false, reason: 'refusing to auto-index home directory' });
+  });
+
+  it('rejects common home builtin directories', () => {
+    for (const dir of ['Downloads', 'Documents', 'Desktop', 'Library', 'Movies', 'Music', 'Pictures']) {
+      expect(validateAutoIndexPath(`/Users/alice/${dir}`)).toEqual({
+        ok: false,
+        reason: 'refusing to auto-index builtin user directory',
+      });
+    }
+  });
+
+  it('accepts deeper paths under home', () => {
+    expect(validateAutoIndexPath('/Users/alice/code/thing')).toEqual({
+      ok: true,
+      path: '/Users/alice/code/thing',
+    });
+  });
+
+  it('rejects empty paths', () => {
+    expect(validateAutoIndexPath('')).toEqual({ ok: false, reason: 'path is empty' });
+  });
+
+  it('normalizes trailing slashes and backslashes', () => {
+    expect(validateAutoIndexPath('/Users/alice/Projects/felan/')).toEqual({
+      ok: true,
+      path: '/Users/alice/Projects/felan',
+    });
+  });
+});

--- a/packages/ext-codebase-memory/test/extension.test.ts
+++ b/packages/ext-codebase-memory/test/extension.test.ts
@@ -94,11 +94,11 @@ describe('Codebase Memory extension', () => {
 
     await vi.waitFor(() => {
       expect(harness.notifications).toEqual(expect.arrayContaining([
-        [expect.stringContaining('refusing to auto-index home directory'), 'info'],
+        [expect.stringContaining('refusing to auto-index home directory'), 'warning'],
       ]));
     });
     expect(runtime.shellCalls.filter((call) => call.command.includes('index_repository'))).toHaveLength(0);
-    expect(harness.notifications.at(-1)?.[0]).toContain('codebase_memory({command: "index_repository"');
+    expect(harness.notifications.at(-1)?.[0]).toContain('ask the agent to index it explicitly');
   });
 
   it('skips auto-indexing when git rev-parse resolves to the user home directory', async () => {
@@ -109,7 +109,9 @@ describe('Codebase Memory extension', () => {
     await harness.emit('session_start', { reason: 'startup' });
 
     await vi.waitFor(() => {
-      expect(harness.notifications.at(-1)?.[0]).toContain('home directory');
+      expect(harness.notifications).toEqual(expect.arrayContaining([
+        [expect.stringContaining('home directory'), 'warning'],
+      ]));
     });
     expect(runtime.shellCalls.filter((call) => call.command.includes('index_repository'))).toHaveLength(0);
   });
@@ -123,26 +125,78 @@ describe('Codebase Memory extension', () => {
 
     await vi.waitFor(() => {
       expect(harness.notifications).toEqual(expect.arrayContaining([
-        [expect.stringContaining('refusing to auto-index system directory'), 'info'],
+        [expect.stringContaining('refusing to auto-index system directory'), 'warning'],
       ]));
     });
     expect(runtime.shellCalls.filter((call) => call.command.includes('index_repository'))).toHaveLength(0);
   });
 
-  it('allows an explicit repo_path through the proxy even for paths that would auto-reject', async () => {
+  it('returns informative error and disables grep augmentation when directory is not auto-indexed', async () => {
+    const telemetry = vi.fn();
+    const runtime = new MemoryRuntime('host', true, async (command) => {
+      if (command.includes('search_code')) throw new Error('should not search unindexed directory');
+      return result(envelope({}));
+    });
+    runtime.cwd = '/Users/alice';
+    runtime.gitTopLevel = undefined;
+    const harness = await createHarness(runtime, createCodebaseMemoryExtension({ telemetry }));
+
+    await harness.emit('session_start', { reason: 'startup' });
+
+    const symbolResponse = await execute(harness.tools[1]!, { name: 'answer' });
+    expect(textOf(symbolResponse)).toContain('This folder is not auto-indexed due to: refusing to auto-index home directory');
+    expect(textOf(symbolResponse)).toContain('Index it only after explicit user approval/request');
+
+    const searchResponse = await execute(harness.tools[3]!, { pattern: 'answer' });
+    expect(textOf(searchResponse)).toContain('This folder is not auto-indexed due to: refusing to auto-index home directory');
+
+    const proxyResponse = await execute(harness.tools[0]!, { command: 'search_graph', arguments: { query: 'answer' } });
+    expect(textOf(proxyResponse)).toContain('This folder is not auto-indexed due to: refusing to auto-index home directory');
+
+    await harness.emit('tool_call', {
+      type: 'tool_call',
+      toolName: 'bash',
+      toolCallId: 'grep-unindexed',
+      input: { command: "grep -R 'Needle' src" },
+    });
+    const augmented = await harness.emit('tool_result', {
+      type: 'tool_result',
+      toolName: 'bash',
+      toolCallId: 'grep-unindexed',
+      input: { command: "grep -R 'Needle' src" },
+      content: [{ type: 'text', text: 'src/a.ts:3:Needle' }],
+      details: {},
+      isError: false,
+    });
+    expect(augmented).toBeUndefined();
+    expect(telemetry).not.toHaveBeenCalledWith('grep_augmentation', expect.anything());
+  });
+
+  it('allows an explicit repo_path through the proxy even for paths that would auto-reject and enables searches', async () => {
     const runtime = new MemoryRuntime('host', true, async (command) => {
       if (command.includes('index_repository')) return result(envelope({ status: 'indexed', project: 'fixture' }));
       if (command.includes('list_projects')) return result(envelope({ projects: [] }));
+      if (command.includes('search_graph')) return result(envelope({ results: [{ qualified_name: 'fixture.answer' }] }));
+      if (command.includes('get_code_snippet')) return result(envelope({ code: '42' }));
       return result(envelope({}));
     });
+    runtime.cwd = '/Users/alice';
     runtime.gitTopLevel = undefined;
     const harness = await createHarness(runtime);
+
+    await harness.emit('session_start', { reason: 'startup' });
+
+    const beforeIndex = await execute(harness.tools[1]!, { name: 'answer' });
+    expect(textOf(beforeIndex)).toContain('refusing to auto-index home directory');
 
     await execute(harness.tools[0]!, { command: 'index_repository', arguments: { repo_path: '/tmp/scratch-repo' } });
 
     const indexed = runtime.shellCalls.filter((call) => call.command.includes('index_repository'));
     expect(indexed).toHaveLength(1);
     expect(indexed[0]?.command).toContain('/tmp/scratch-repo');
+
+    const afterIndex = await execute(harness.tools[1]!, { name: 'answer' });
+    expect(textOf(afterIndex)).toContain('42');
   });
 
   it('registers exactly four tools, background startup indexing, accurate freshness guidance, and explicit refresh paths', async () => {
@@ -465,6 +519,11 @@ describe('Codebase Memory extension', () => {
 
 async function execute(tool: ToolDefinition, params: Record<string, unknown>) {
   return tool.execute('call', params as never, new AbortController().signal, () => {}, {} as never);
+}
+
+function textOf(response: { content: Array<{ type: string; text?: string }> }): string {
+  const content = response.content[0];
+  return content?.type === 'text' && typeof content.text === 'string' ? content.text : '';
 }
 
 function renderedCall(tool: ToolDefinition, params: Record<string, unknown>): string {

--- a/packages/ext-codebase-memory/test/extension.test.ts
+++ b/packages/ext-codebase-memory/test/extension.test.ts
@@ -67,8 +67,26 @@ describe('Codebase Memory extension', () => {
     expect(harness.capabilities).toEqual([]);
   });
 
-  it('skips auto-indexing when the cwd is not inside a git repository', async () => {
+  it('auto-indexes a non-git working directory when path is valid', async () => {
+    const runtime = new MemoryRuntime('host', true, async (command) => {
+      if (command.includes('index_repository')) return result(envelope({ status: 'indexed', project: 'repo' }));
+      if (command.includes('list_projects')) return result(envelope({ projects: [] }));
+      return result(envelope({}));
+    });
+    runtime.gitTopLevel = undefined;
+    const harness = await createHarness(runtime);
+
+    await harness.emit('session_start', { reason: 'startup' });
+
+    await vi.waitFor(() => {
+      const indexed = runtime.shellCalls.filter((call) => call.command.includes('index_repository'));
+      expect(indexed.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('skips auto-indexing when launched in user home directory without git', async () => {
     const runtime = new MemoryRuntime('host', true);
+    runtime.cwd = '/Users/alice';
     runtime.gitTopLevel = undefined;
     const harness = await createHarness(runtime);
 
@@ -76,7 +94,7 @@ describe('Codebase Memory extension', () => {
 
     await vi.waitFor(() => {
       expect(harness.notifications).toEqual(expect.arrayContaining([
-        [expect.stringContaining('no git repository detected'), 'info'],
+        [expect.stringContaining('refusing to auto-index home directory'), 'info'],
       ]));
     });
     expect(runtime.shellCalls.filter((call) => call.command.includes('index_repository'))).toHaveLength(0);
@@ -92,6 +110,21 @@ describe('Codebase Memory extension', () => {
 
     await vi.waitFor(() => {
       expect(harness.notifications.at(-1)?.[0]).toContain('home directory');
+    });
+    expect(runtime.shellCalls.filter((call) => call.command.includes('index_repository'))).toHaveLength(0);
+  });
+
+  it('skips auto-indexing when target directory is a system directory', async () => {
+    const runtime = new MemoryRuntime('host', true);
+    runtime.gitTopLevel = 'C:\\Windows';
+    const harness = await createHarness(runtime);
+
+    await harness.emit('session_start', { reason: 'startup' });
+
+    await vi.waitFor(() => {
+      expect(harness.notifications).toEqual(expect.arrayContaining([
+        [expect.stringContaining('refusing to auto-index system directory'), 'info'],
+      ]));
     });
     expect(runtime.shellCalls.filter((call) => call.command.includes('index_repository'))).toHaveLength(0);
   });

--- a/packages/ext-codebase-memory/test/extension.test.ts
+++ b/packages/ext-codebase-memory/test/extension.test.ts
@@ -67,6 +67,51 @@ describe('Codebase Memory extension', () => {
     expect(harness.capabilities).toEqual([]);
   });
 
+  it('skips auto-indexing when the cwd is not inside a git repository', async () => {
+    const runtime = new MemoryRuntime('host', true);
+    runtime.gitTopLevel = undefined;
+    const harness = await createHarness(runtime);
+
+    await harness.emit('session_start', { reason: 'startup' });
+
+    await vi.waitFor(() => {
+      expect(harness.notifications).toEqual(expect.arrayContaining([
+        [expect.stringContaining('no git repository detected'), 'info'],
+      ]));
+    });
+    expect(runtime.shellCalls.filter((call) => call.command.includes('index_repository'))).toHaveLength(0);
+    expect(harness.notifications.at(-1)?.[0]).toContain('codebase_memory({command: "index_repository"');
+  });
+
+  it('skips auto-indexing when git rev-parse resolves to the user home directory', async () => {
+    const runtime = new MemoryRuntime('host', true);
+    runtime.gitTopLevel = '/Users/alice';
+    const harness = await createHarness(runtime);
+
+    await harness.emit('session_start', { reason: 'startup' });
+
+    await vi.waitFor(() => {
+      expect(harness.notifications.at(-1)?.[0]).toContain('home directory');
+    });
+    expect(runtime.shellCalls.filter((call) => call.command.includes('index_repository'))).toHaveLength(0);
+  });
+
+  it('allows an explicit repo_path through the proxy even for paths that would auto-reject', async () => {
+    const runtime = new MemoryRuntime('host', true, async (command) => {
+      if (command.includes('index_repository')) return result(envelope({ status: 'indexed', project: 'fixture' }));
+      if (command.includes('list_projects')) return result(envelope({ projects: [] }));
+      return result(envelope({}));
+    });
+    runtime.gitTopLevel = undefined;
+    const harness = await createHarness(runtime);
+
+    await execute(harness.tools[0]!, { command: 'index_repository', arguments: { repo_path: '/tmp/scratch-repo' } });
+
+    const indexed = runtime.shellCalls.filter((call) => call.command.includes('index_repository'));
+    expect(indexed).toHaveLength(1);
+    expect(indexed[0]?.command).toContain('/tmp/scratch-repo');
+  });
+
   it('registers exactly four tools, background startup indexing, accurate freshness guidance, and explicit refresh paths', async () => {
     const telemetry = vi.fn();
     const runtime = new MemoryRuntime('host', true, async (command) => {

--- a/packages/ext-codebase-memory/test/package.test.ts
+++ b/packages/ext-codebase-memory/test/package.test.ts
@@ -11,7 +11,7 @@ describe('@felan-ai/ext-codebase-memory package boundary', () => {
     const notice = await readFile(join(packageRoot, 'NOTICE'), 'utf8');
     expect(manifest).toMatchObject({
       name: '@felan-ai/ext-codebase-memory',
-      version: '0.1.5',
+      version: '0.1.6',
       peerDependencies: { '@felan-ai/agent-core': '^0.5.0' },
       publishConfig: { access: 'public', provenance: true },
     });

--- a/packages/ext-codebase-memory/test/test-runtime.ts
+++ b/packages/ext-codebase-memory/test/test-runtime.ts
@@ -7,7 +7,7 @@ import type {
 import { codebaseMemoryRuntimeDirectory } from '../src/runtime-path.js';
 
 export class MemoryRuntime implements AgentRuntime {
-  readonly cwd = '/work/repo';
+  cwd: string = '/work/repo';
   readonly files = new Map<string, Uint8Array>();
   readonly execCalls: Array<{ command: string; args: readonly string[]; options?: ExecOptions }> = [];
   readonly shellCalls: Array<{ command: string; options?: Record<string, unknown> }> = [];

--- a/packages/ext-codebase-memory/test/test-runtime.ts
+++ b/packages/ext-codebase-memory/test/test-runtime.ts
@@ -16,6 +16,7 @@ export class MemoryRuntime implements AgentRuntime {
     ensureDirectory: async (_namespace: string) => codebaseMemoryRuntimeDirectory(this.storageRoot).root,
   };
   version = '0.10.8';
+  gitTopLevel: string | undefined = '/work/repo';
 
   constructor(
     readonly kind: AgentRuntime['kind'] = 'host',
@@ -51,6 +52,10 @@ export class MemoryRuntime implements AgentRuntime {
     this.execCalls.push({ command, args, ...(options === undefined ? {} : { options }) });
     if (args.includes('--version')) {
       return this.available ? result(`codebase-memory-mcp ${this.version}\n`) : result('', 127, 'not found');
+    }
+    if (command === 'git' && args[0] === 'rev-parse' && args[1] === '--show-toplevel') {
+      if (this.gitTopLevel === undefined) return result('', 128, 'fatal: not a git repository');
+      return result(`${this.gitTopLevel}\n`);
     }
     return result();
   }


### PR DESCRIPTION
Closes #30.

## Summary

Refuses to auto-index when Felan is launched outside a git repository, or when `git rev-parse --show-toplevel` resolves to a system directory, home directory, or filesystem root. Users get a clear one-time notification with the explicit escape hatch instead of a silent, expensive, mixed-content index.

## Real-world validation

The failure mode described in #30 was reproduced accidentally during local testing of v0.19.0. Concrete observations:

- **Scope explosion.** Launching Felan from `~/Projects/FelanAI` (not a git repo, parent of `felan`, `felan-platform`, `felan-cli`, `pi-extensions`, `go-to-market`, `skills`, and `bugzy-platform-bug-106-dreaming-learning-loop`) produced a single indexed project named `Users-yavorboychev-Projects-FelanAI` with **94,022 nodes and 260,022 edges** — a mixed graph spanning every sub-repo. Initial indexing took ~15 seconds, so the failure is silent, not obviously expensive.
- **Latency collapse.** Symbol searches on the workspace-blob took **30–70 seconds per call** (measurements: `ProjectService` 47s, `SessionRunner` 1m 10s, `search_code` for a common pattern 30s). A properly scoped single-repo index of the same repos returns similar queries in 1–3 seconds. Interactive use becomes untenable at these latencies; each tool call also consumes model turn budget on the AI SDK side.
- **Silent cross-repo narrowing.** Searching for `SessionRunner` (a class that exists in both `felan-platform/apps/agent/src/sessions/session-runner.ts` and its `bugzy-platform-bug-106-dreaming-learning-loop` fork) returned only the felan-platform hit through the model's summary. The tool call succeeded, but half the answer was quietly dropped without any user-visible indication. This is worse than confusion because the user doesn't know they're missing signal.
- **Cache pollution.** The polluted 94k-node blob had to be manually deleted from `~/.felan/codebase-memory/cache/` because `delete_project` is not exposed through the proxy allowlist. LRU treats it as one entry, so it would eventually evict as a coarse unit.

These observations were produced in ~90 minutes of normal local use. The fix in this PR is the minimum change that prevents all four failure modes.

## Root cause

`ProjectService.gitRoot()` silently fell back to `runtime.cwd` when the launch directory was not in a git repo. `index()` then passed that path to `codebase-memory-mcp index_repository` with no validation.

See #30 for the full walkthrough.

## What changed

- **`src/auto-index-paths.ts` (new)** — `validateAutoIndexPath()` with a denylist for filesystem roots, system dirs, home dir itself, and home builtins (Downloads, Documents, etc.).
- **`src/services.ts`** — `gitRoot()` now returns `string | undefined` (honest signal). `index()` returns a discriminated `IndexResult` (`indexed` | `skipped`), accepts an optional explicit `repoPath`, and runs the path guard for auto-index only. `project()` falls back to `runtime.cwd` for the `list_projects` lookup when there is no git root.
- **`src/index.ts`** — `refresh()` handles the `skipped` result: clears the status indicator and notifies with an actionable message, including the `codebase_memory({command: "index_repository", arguments: {repo_path: "..."}})` escape hatch for legitimate off-tree indexing.
- **`src/tools.ts`** — the `codebase_memory` proxy now passes `args.repo_path` through to `projects.index()`. Also fixes a pre-existing side bug where the argument was silently ignored.

## Tests

- 8 new unit tests in `test/auto-index-paths.test.ts` covering every guard branch (roots, system paths, home dir, home builtins, empty, normalization, deeper allowed paths)
- 3 new integration tests in `test/extension.test.ts`:
  - Skip on session start when cwd is not in a git repo — no `index_repository` call, correct notification with escape-hatch text
  - Skip when git resolves to `/Users/alice` — reason mentions "home directory"
  - Explicit `repo_path` via the proxy bypasses the guard and indexes the requested path even when auto-index would refuse
- `test/test-runtime.ts` gained a configurable `gitTopLevel` so tests can simulate the "no repo" and "bad path" cases without stubbing exec directly

## Verification

- [x] `pnpm --filter @felan-ai/ext-codebase-memory test` — 35 passed, 1 skipped
- [x] `pnpm verify` at repo root — passes (check:licenses, build, type-check, test, pack:all, test:packed-bin)
- [x] Type-check clean on new/modified files (two pre-existing agent-core `readFile` signature errors in `cache.ts` and `installer.ts` remain; not from this PR)
- [x] Manually reproduced the #30 failure on v0.19.0 (see Real-world validation)
- [ ] Manually re-verified with fix branch build — recommended before merge

## User experience

Before: launching Felan in the wrong dir triggered a silent multi-minute index that filled the cache with unwanted content, then produced 30–70s tool calls with silently narrowed results.

After: one-time notification —

> *Codebase Memory: no git repository detected at current directory — skipped auto-indexing. Launch Felan from inside a git repo, or index a specific path via `codebase_memory({command: "index_repository", arguments: {repo_path: "/path/to/repo"}})`.*

No index runs, no cache pollution, no silent narrowing later.