### PR TITLE
fix(codebase-memory): read_symbol returns source for both call shapes

### DIFF
--- a/apps/tui/package.json
+++ b/apps/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felan-ai/felan",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "description": "Open-source, model-portable coding agent built for cost-efficient, verifiable software work",
   "keywords": [
     "ai",

--- a/packages/ext-codebase-memory/package.json
+++ b/packages/ext-codebase-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felan-ai/ext-codebase-memory",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Portable Codebase Memory tools and grep augmentation for Felan",
   "license": "MIT",
   "type": "module",

--- a/packages/ext-codebase-memory/src/services.ts
+++ b/packages/ext-codebase-memory/src/services.ts
@@ -112,7 +112,7 @@ export class SymbolService {
           || candidate.name === requestedName
           || qualifiedName.split('.').at(-1) === requestedName)
         && (!params.qualified_name || qualifiedName === params.qualified_name)
-        && (!params.file_path || String(candidate.file_path ?? '').includes(String(params.file_path)));
+        && (!params.file_path || String(candidate.file ?? candidate.file_path ?? '').includes(String(params.file_path)));
     });
     if (matches.length > 1) {
       return {
@@ -163,11 +163,22 @@ function searchCandidates(value: unknown): unknown[] {
   const results = arrayProperty(value, 'results');
   if (results.length > 0) return results;
   const record = asRecord(value);
-  if (!Array.isArray(record.cols) || !Array.isArray(record.rows)) return [];
+  if (!Array.isArray(record.cols)) return [];
   const columns = record.cols.filter((column): column is string => typeof column === 'string');
-  return record.rows.filter(Array.isArray).map((row) => Object.fromEntries(
+  if (Array.isArray(record.groups)) return searchGroupedCandidates(record, columns);
+  return arrayProperty(record, 'rows').filter(Array.isArray).map((row) => Object.fromEntries(
     columns.map((column, index) => [column === 'qn' ? 'qualified_name' : column, row[index]]),
   ));
+}
+
+function searchGroupedCandidates(record: Record<string, unknown>, columns: readonly string[]): unknown[] {
+  return arrayProperty(record, 'groups').flatMap((group) => {
+    const { qn_prefix: prefix, file } = asRecord(group);
+    return arrayProperty(group, 'rows').filter(Array.isArray).map((row) => {
+      const candidate = Object.fromEntries(columns.map((column, index) => [column, row[index]]));
+      return { ...candidate, file, qualified_name: `${prefix}.${candidate.name}` };
+    });
+  });
 }
 
 function projectName(path: string): string {

--- a/packages/ext-codebase-memory/test/extension.test.ts
+++ b/packages/ext-codebase-memory/test/extension.test.ts
@@ -242,7 +242,13 @@ describe('Codebase Memory extension', () => {
     const source = Array.from({ length: 300 }, (_, index) => `line ${index + 1}`).join('\n');
     const runtime = new MemoryRuntime('host', true, async (command) => {
       if (command.includes('list_projects')) return result(envelope({ projects: [] }));
-      if (command.includes('search_graph')) return result(envelope({ results: [{ qualified_name: 'fixture.answer' }] }));
+      if (command.includes('search_graph')) {
+        return result(envelope({
+          total: 1,
+          cols: ['qn', 'label', 'file', 'lines', 'rank'],
+          rows: [['fixture.answer', 'Function', 'src/answer.ts', '1-3', 1]],
+        }));
+      }
       if (command.includes('get_code_snippet')) return result(envelope({ code: source }));
       return result(envelope({}));
     });
@@ -257,14 +263,50 @@ describe('Codebase Memory extension', () => {
     expect(payload.snippet.truncated).toBe(true);
   });
 
+  it('reads symbols from real flat and grouped search_graph response shapes', async () => {
+    const runtime = new MemoryRuntime('host', true, async (command) => {
+      if (command.includes('list_projects')) return result(envelope({ projects: [{ name: 'fixture', root_path: '/work/repo' }] }));
+      if (command.includes('search_graph') && command.includes('qn_pattern')) {
+        return result(envelope({
+          total: 1,
+          count: 1,
+          cols: ['name', 'label', 'lines', 'in', 'out'],
+          groups: [{ qn_prefix: 'fixture.src.answer', file: 'src/answer.ts', rows: [['answer', 'Function', '1-3', 0, 1]] }],
+        }));
+      }
+      if (command.includes('search_graph')) {
+        return result(envelope({
+          total: 1,
+          cols: ['qn', 'label', 'file', 'lines', 'rank'],
+          rows: [['fixture.src.answer.answer', 'Function', 'src/answer.ts', '1-3', 1]],
+        }));
+      }
+      if (command.includes('get_code_snippet')) return result(envelope({ source: 'export function answer() { return 42; }' }));
+      return result(envelope({}));
+    });
+    const harness = await createHarness(runtime);
+
+    for (const params of [
+      { qualified_name: 'fixture.src.answer.answer' },
+      { name: 'answer', file_path: 'src/answer.ts' },
+    ]) {
+      const response = await execute(harness.tools[1]!, params);
+      const content = response.content[0];
+      const payload = JSON.parse(content?.type === 'text' ? content.text : '') as { snippet: { source: string } };
+      expect(payload.snippet.source).toContain('return 42');
+    }
+  });
+
   it('fails closed when a symbol name is ambiguous', async () => {
     const runtime = new MemoryRuntime('host', true, async (command) => {
       if (command.includes('list_projects')) return result(envelope({ projects: [] }));
       if (command.includes('search_graph')) {
         return result(envelope({
-          results: [
-            { qualified_name: 'fixture.first.answer', file_path: 'src/first.ts' },
-            { qualified_name: 'fixture.second.answer', file_path: 'src/second.ts' },
+          total: 2,
+          cols: ['qn', 'label', 'file', 'lines', 'rank'],
+          rows: [
+            ['fixture.first.answer', 'Function', 'src/first.ts', '1-3', 1],
+            ['fixture.second.answer', 'Function', 'src/second.ts', '1-3', 1],
           ],
         }));
       }

--- a/packages/ext-codebase-memory/test/package.test.ts
+++ b/packages/ext-codebase-memory/test/package.test.ts
@@ -11,7 +11,7 @@ describe('@felan-ai/ext-codebase-memory package boundary', () => {
     const notice = await readFile(join(packageRoot, 'NOTICE'), 'utf8');
     expect(manifest).toMatchObject({
       name: '@felan-ai/ext-codebase-memory',
-      version: '0.1.2',
+      version: '0.1.3',
       peerDependencies: { '@felan-ai/agent-core': '^0.5.0' },
       publishConfig: { access: 'public', provenance: true },
     });

--- a/packages/ext-codebase-memory/test/real-binary.e2e.test.ts
+++ b/packages/ext-codebase-memory/test/real-binary.e2e.test.ts
@@ -3,6 +3,8 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   HostAgentRuntime,
+  type ExecOptions,
+  type ExecResult,
   type ExtensionContext,
   type FelanExtensionAPI,
   type ToolDefinition,
@@ -56,7 +58,10 @@ describe('Codebase Memory real binary', () => {
         ['codebase-memory', undefined],
       ]);
     }, { timeout: 120_000 });
-    expect(await readSymbol(harness.tools[1]!, 'answer')).toContain('return 42');
+    const byNameAndFile = await readSymbolPayload(harness.tools[1]!, { name: 'answer', file_path: 'answer.ts' });
+    expect(byNameAndFile.snippet.source).toContain('return 42');
+    const byQualifiedName = await readSymbolPayload(harness.tools[1]!, { qualified_name: byNameAndFile.symbol.qualified_name });
+    expect(byQualifiedName.snippet.source).toContain('return 42');
 
     await writeFile(join(workspace, 'answer.ts'), 'export function changedAnswer() { return 84; }\n');
     expect(await readSymbol(harness.tools[1]!, 'changedAnswer')).toContain('No matching symbol found');
@@ -68,7 +73,7 @@ describe('Codebase Memory real binary', () => {
     expect(await readSymbol(harness.tools[1]!, 'slashAnswer')).toContain('return 126');
     await harness.emit('session_shutdown', { reason: 'quit' });
 
-    const missingRuntime = new HostAgentRuntime(workspace, {
+    const missingRuntime = new MissingBinaryRuntime(workspace, {
       sessionStorageRoot: join(root, 'missing-session'),
       agentStorageRoot: join(root, 'missing-agent'),
     });
@@ -126,8 +131,26 @@ async function readSymbol(tool: ToolDefinition, name: string): Promise<string> {
   return content?.type === 'text' ? content.text : '';
 }
 
+async function readSymbolPayload(tool: ToolDefinition, params: Record<string, unknown>) {
+  const result = await executeTool(tool, params);
+  const content = result.content[0];
+  return JSON.parse(content?.type === 'text' ? content.text : 'null') as {
+    symbol: { qualified_name: string };
+    snippet: { source: string };
+  };
+}
+
 function executeTool(tool: ToolDefinition, params: Record<string, unknown>) {
   return tool.execute('e2e', params as never, new AbortController().signal, () => {}, {} as never);
+}
+
+class MissingBinaryRuntime extends HostAgentRuntime {
+  override async exec(command: string, args: readonly string[], options?: ExecOptions): Promise<ExecResult> {
+    if (args.includes('--version') && command.endsWith('codebase-memory-mcp')) {
+      return { stdout: '', stderr: 'not found', code: 127, killed: false };
+    }
+    return super.exec(command, args, options);
+  }
 }
 
 async function runGit(cwd: string, args: readonly string[]): Promise<void> {

--- a/packages/ext-insights/test/index.test.ts
+++ b/packages/ext-insights/test/index.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createInsightsExtension } from '../src/index.js';
 
 describe('createInsightsExtension', () => {
+  afterEach(() => { vi.useRealTimers(); });
+
   it('registers the bounded insights command and reports an empty range', async () => {
     let command: { handler: (args: string, ctx: unknown) => Promise<void> } | undefined;
     const notify = vi.fn();
@@ -42,6 +44,9 @@ describe('createInsightsExtension', () => {
   });
 
   it('counts turns from resumed roots and retained agents inside --since', async () => {
+    // --since resolves against the wall clock, so pin it to keep the fixture timestamps in range.
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-09-01T12:00:00Z'));
     let command: { handler: (args: string, ctx: unknown) => Promise<void> } | undefined;
     let report = '';
     let cache = '';


### PR DESCRIPTION
Fixes #32.

`read_symbol` returned `{"error": "No matching symbol found"}` on every call — 29 calls across 9 sessions, 0 snippets. Both causes the issue identified are addressed.

## Cause A — grouped responses were not parsed

`search_graph` answers `qn_pattern` with `cols` + `groups[].rows`, not the flat `cols` + `rows` it uses for `query`. `searchCandidates` understood only the flat shape, so a real match parsed as zero candidates.

`searchGroupedCandidates` now flattens `groups[]`, rebuilding `qualified_name` from the group's `qn_prefix` plus the row's `name` and taking `file` from the group.

The dispatch keys off the presence of `groups` rather than the absence of `rows`. The issue's suggested reading — "there is no top-level `rows`" — holds for 0.10.8, but a response carrying both would silently take the flat path and return nothing; checking `groups` first costs the same line and removes that coupling.

## Cause B — filtering on a field the binary never emits

The candidate filter tested `candidate.file_path`. The real column is `file`, so `String(undefined ?? '').includes(...)` was always `false` and every candidate was filtered out whenever `file_path` was passed — producing the confusing output where the correct symbol appears in `candidates` next to an error saying it was not found. Now reads `candidate.file ?? candidate.file_path`, keeping the old key for forward compatibility as the issue suggested.

## Tests

The unit mocks asserted a shape the binary never emits — a `results` array plus a `file_path` key, dodging both causes at once. Replaced with real flat and grouped envelopes captured from 0.10.8.

The e2e now asserts `read_symbol` actually returns source, by both call shapes, as a round trip: read by `name` + `file_path`, then feed the returned `qualified_name` back in. That is what validates the `qn_prefix` reconstruction against the real binary rather than against a mock written to match it. Verified locally against `codebase-memory-mcp` 0.10.8 via `CBM_E2E_BINARY`.

Its missing-binary case previously depended on the binary not being on the runner's `PATH`, so it passed or failed by machine. `MissingBinaryRuntime` now forces a non-zero `--version` exit.

## Release

`ext-codebase-memory` 0.1.2 → 0.1.3 and `felan` 0.20.1 → 0.20.2, since `pnpm pack` rewrites the `workspace:*` dependency to the exact version and `test-packed-bin.mjs` asserts they match. The pinned version in `test/package.test.ts` moves with it. `codebase-memory-mcp` stays pinned at 0.10.8 — untouched by this change.

## Unrelated fix included

`ad7bf29` pins the clock in `ext-insights`' `--since` test. It compared hardcoded fixture timestamps against the real wall clock, so it passed only on the day it was written and started failing on 2026-09-02 with no commit behind it. `pnpm verify` cannot reach the publish step while it fails, so the release is blocked on it. Kept as its own commit if you would rather land it separately.

## Verification

`pnpm check:licenses`, `pnpm check:proposed-version`, and `pnpm verify` all pass — build, type-check, every package test, `pack:all`, and `test-packed-bin` against the packed `felan-ai-felan-0.20.2.tgz`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RELubZ61ec2eHKZZ1M8umf