### PR TITLE
fix(ext-codex): bound exec_command output by line length and token ceiling

### DIFF
--- a/packages/ext-codex/README.md
+++ b/packages/ext-codex/README.md
@@ -45,7 +45,12 @@ unsupported, and unresizable images are rejected.
 capability. `write_stdin` sends terminal input; for non-TTY sessions, the exact
 Ctrl-C byte interrupts the process group and other input is rejected. Process
 output is decoded incrementally and terminal control sequences are removed
-before tool text is returned to the model.
+before tool text is returned to the model. Each `exec_command` or `write_stdin`
+result defaults to a 10000-token output budget, clamps requested budgets above
+25000 tokens, shortens individual lines over 2000 characters with an explicit
+`…[line truncated]` marker, and keeps a head-and-tail preview marked
+`[... output truncated ...]` when the total output still exceeds the budget.
+`Original token count` reports the untruncated size.
 
 Initial commands wait 250-30000 ms and default to 10000 ms; Windows uses a
 10000 ms minimum. Non-empty `write_stdin` calls wait 250-30000 ms and default

--- a/packages/ext-codex/src/exec-session-manager.ts
+++ b/packages/ext-codex/src/exec-session-manager.ts
@@ -47,7 +47,12 @@ const MIN_EMPTY_POLL_YIELD_MS = 5_000;
 const MAX_YIELD_MS = 30_000;
 const MAX_EMPTY_POLL_YIELD_MS = 300_000;
 const DEFAULT_MAX_OUTPUT_TOKENS = 10_000;
-const MAX_RETAINED_OUTPUT_CHARS = 4 * 1024 * 1024;
+export const MAX_OUTPUT_TOKENS = 25_000;
+const MAX_RETAINED_OUTPUT_CHARS = MAX_OUTPUT_TOKENS * 4;
+const MAX_RETAINED_LINE_CHARS = 2_000;
+const LONG_LINE_PATTERN = new RegExp(`[^\\n]{${MAX_RETAINED_LINE_CHARS + 1},}`, 'g');
+const LINE_TRUNCATION_MARKER = '…[line truncated]';
+const OUTPUT_TRUNCATION_MARKER = '\n[... output truncated ...]\n';
 const COMPLETED_HISTORY_LIMIT = 32;
 const SESSION_ID_MIN = 1_000;
 const SESSION_ID_MAX_EXCLUSIVE = 100_000;
@@ -310,7 +315,7 @@ export class ExecSessionManager {
     startedAt: number,
   ): Promise<void> {
     const combined = `${session.pendingOutput}${read.output}`;
-    session.pendingOutput = tail(combined, MAX_RETAINED_OUTPUT_CHARS);
+    session.pendingOutput = headAndTail(clampLongLines(combined), MAX_RETAINED_OUTPUT_CHARS);
     session.pendingOriginalCharCount += read.originalCharCount;
     if (!read.running) {
       const result = this.#consumeRead(
@@ -404,7 +409,7 @@ async function readFor(
     const decoded = session.decoder.decode(snapshot.output, { stream: snapshot.running });
     const sanitized = session.sanitizer.write(decoded, !snapshot.running);
     originalCharCount += sanitized.length;
-    output = tail(`${output}${sanitized}`, maxChars);
+    output = headAndTail(clampLongLines(`${output}${sanitized}`), maxChars);
     offset = snapshot.nextOffset;
     if (!snapshot.running || signal?.aborted) break;
     const remaining = deadline - Date.now();
@@ -440,14 +445,15 @@ function truncateOutput(
   original_token_count?: number;
 } {
   const maxChars = maxCharsForTokens(maxOutputTokens);
+  const clampedOutput = clampLongLines(output);
   const originalTokenCount = Math.ceil(Math.max(output.length, originalCharCount) / 4);
-  if (output.length <= maxChars) {
-    return output || originalCharCount > 0
-      ? { output, original_token_count: originalTokenCount }
-      : { output };
+  if (clampedOutput.length <= maxChars) {
+    return clampedOutput || originalCharCount > 0
+      ? { output: clampedOutput, original_token_count: originalTokenCount }
+      : { output: clampedOutput };
   }
   return {
-    output: tail(output, maxChars),
+    output: headAndTail(clampedOutput, maxChars),
     original_token_count: originalTokenCount,
   };
 }
@@ -459,7 +465,29 @@ function maxCharsForTokens(maxOutputTokens = DEFAULT_MAX_OUTPUT_TOKENS): number 
   return Math.min(MAX_RETAINED_OUTPUT_CHARS, requested);
 }
 
-function tail(output: string, maxChars: number): string {
+function clampLongLines(output: string): string {
+  return output.replace(
+    LONG_LINE_PATTERN,
+    (line) => `${safeHead(line, MAX_RETAINED_LINE_CHARS)}${LINE_TRUNCATION_MARKER}`,
+  );
+}
+
+function headAndTail(output: string, maxChars: number): string {
+  if (output.length <= maxChars) return output;
+  const retained = maxChars - OUTPUT_TRUNCATION_MARKER.length;
+  if (retained <= 0) return safeHead(output, maxChars);
+  const head = safeHead(output, Math.ceil(retained / 2));
+  const tail = safeTail(output, Math.floor(retained / 2));
+  return `${head}${OUTPUT_TRUNCATION_MARKER}${tail}`;
+}
+
+function safeHead(output: string, maxChars: number): string {
+  let end = Math.min(output.length, Math.max(0, maxChars));
+  if (end > 0 && /[\uD800-\uDBFF]/u.test(output[end - 1]!)) end -= 1;
+  return output.slice(0, end);
+}
+
+function safeTail(output: string, maxChars: number): string {
   let start = Math.max(0, output.length - maxChars);
   if (start > 0 && /[\uDC00-\uDFFF]/u.test(output[start]!)) start += 1;
   return output.slice(start);

--- a/packages/ext-codex/src/index.ts
+++ b/packages/ext-codex/src/index.ts
@@ -55,7 +55,7 @@ const codexExtension: FelanExtension = async (pi) => {
 
 export { CODEX_CONFIG, DEFAULT_CODEX_CONFIG, validateCodexConfig } from './config.js';
 export type { CodexConfig, CodexVerbosity } from './config.js';
-export { ExecSessionManager, formatExecResult } from './exec-session-manager.js';
+export { ExecSessionManager, MAX_OUTPUT_TOKENS, formatExecResult } from './exec-session-manager.js';
 export type { ExecCommandInput, UnifiedExecResult, WriteStdinInput } from './exec-session-manager.js';
 export { supportsCodexModel, supportsCodexResponsesRequest } from './model-policy.js';
 export { applyCodexRequestOptions } from './request-options.js';

--- a/packages/ext-codex/src/tools.ts
+++ b/packages/ext-codex/src/tools.ts
@@ -16,7 +16,7 @@ const ExecCommandParams = Type.Object({
   shell: Type.Optional(Type.String()),
   tty: Type.Optional(Type.Boolean({ description: 'Run the command in a real PTY for ongoing interaction' })),
   yield_time_ms: Type.Optional(Type.Number({ description: 'Wait before yielding output. Defaults to 10000 ms and clamps to 250-30000 ms; Windows uses a 10000 ms minimum.' })),
-  max_output_tokens: Type.Optional(Type.Number({ description: 'Output token budget. Defaults to 10000 tokens; larger requests may be capped by policy.' })),
+  max_output_tokens: Type.Optional(Type.Number({ description: 'Output token budget. Defaults to 10000 tokens and caps at 25000 tokens; long lines are clamped before head/tail truncation.' })),
   login: Type.Optional(Type.Boolean({ description: 'Login shell' })),
 }, { additionalProperties: false });
 
@@ -24,7 +24,7 @@ const WriteStdinParams = Type.Object({
   session_id: Type.Number({ description: 'Session ID' }),
   chars: Type.Optional(Type.String({ description: 'Bytes to write to stdin. Defaults to empty, which polls without writing.' })),
   yield_time_ms: Type.Optional(Type.Number({ description: 'Wait before yielding output. Non-empty writes default to 250 ms and cap at 30000 ms; empty polls wait 5000-300000 ms by default.' })),
-  max_output_tokens: Type.Optional(Type.Number({ description: 'Output token budget. Defaults to 10000 tokens; larger requests may be capped by policy.' })),
+  max_output_tokens: Type.Optional(Type.Number({ description: 'Output token budget. Defaults to 10000 tokens and caps at 25000 tokens; long lines are clamped before head/tail truncation.' })),
 }, { additionalProperties: false });
 
 const ApplyPatchParams = Type.Object({

--- a/packages/ext-codex/test/tools.test.ts
+++ b/packages/ext-codex/test/tools.test.ts
@@ -15,6 +15,7 @@ import {
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   ExecSessionManager,
+  MAX_OUTPUT_TOKENS,
   MAX_VIEW_IMAGE_INPUT_BYTES,
   createCodexTools,
   formatExecResult,
@@ -84,17 +85,42 @@ describe('Codex runtime-backed tools', () => {
     await sessions.shutdown();
   });
 
+  it('clamps long lines while keeping nearby useful output', async () => {
+    const runtime = await createRuntime();
+    const sessions = new ExecSessionManager(runtime);
+    const script = [
+      "process.stdout.write('dist/main.js.map:1:needle' + 'x'.repeat(200000) + '\\n')",
+      "process.stdout.write('dist/main.js:1:needle\\n')",
+    ].join(';');
+
+    const result = await sessions.exec({
+      cmd: `${JSON.stringify(process.execPath)} -e ${JSON.stringify(script)}`,
+      yield_time_ms: 30_000,
+    });
+
+    expect(result.output.length).toBeLessThan(5_000);
+    expect(result.output).toContain('dist/main.js.map:1:needle');
+    expect(result.output).toContain('…[line truncated]');
+    expect(result.output).toContain('dist/main.js:1:needle');
+    expect(result.original_token_count).toBeGreaterThan(40_000);
+    await sessions.shutdown();
+  });
+
   it('enforces a fixed retained-output ceiling even when a larger limit is requested', async () => {
     const runtime = await createRuntime();
     const sessions = new ExecSessionManager(runtime);
+    const script = "for (let i = 0; i < 150; i += 1) process.stdout.write(String(i).padStart(3, '0') + ':' + 'x'.repeat(996) + '\\n')";
     const result = await sessions.exec({
-      cmd: `${JSON.stringify(process.execPath)} -e "process.stdout.write('x'.repeat(5 * 1024 * 1024))"`,
+      cmd: `${JSON.stringify(process.execPath)} -e ${JSON.stringify(script)}`,
       yield_time_ms: 30_000,
       max_output_tokens: Number.MAX_SAFE_INTEGER,
     });
 
-    expect(result.output).toHaveLength(4 * 1024 * 1024);
-    expect(result.original_token_count).toBe(5 * 1024 * 1024 / 4);
+    expect(result.output).toHaveLength(MAX_OUTPUT_TOKENS * 4);
+    expect(result.output).toContain('000:');
+    expect(result.output).toContain('\n[... output truncated ...]\n');
+    expect(result.output).toContain('149:');
+    expect(result.original_token_count).toBe(37_538);
     await sessions.shutdown();
   });
 


### PR DESCRIPTION
Closes #33.

## Problem

`exec_command` trimmed output by total character count only. A source map or any minified file holds its whole contents on one line, so a single matched line can be 119,000+ characters. One ordinary `grep -R` over a `dist/` folder returned 120 KB from six matched lines, of which 319 bytes were useful — and that blob then rode in the conversation for the rest of the session. The failure is invisible to the agent: it sees a truncated blob, cannot tell that 99.7% of it was one source-map line, and often re-runs a narrower grep a step later, by which point the blob is already in context permanently.

## Changes

All in `packages/ext-codex/src/exec-session-manager.ts`.

1. **Per-line clamp.** `clampLongLines` shortens any line over 2000 characters to its head plus a `…[line truncated]` marker, applied *before* the total-size trim. No useful grep hit is 100k characters. This also covers minified JS, bundled `dist/`, base64 blobs, single-line JSON, and wide CSV, and changes nothing for ordinary output.
2. **A real ceiling.** The schema said *"larger requests may be capped by policy"* while `maxCharsForTokens` clamped only to 4 MiB (~1M tokens). `MAX_OUTPUT_TOKENS = 25_000` is now enforced, and the `max_output_tokens` descriptions on both `exec_command` and `write_stdin` say so.
3. **Head-and-tail instead of tail-only.** Grep hits are at the top, build failures at the end. `headAndTail` keeps a slice of each with a `[... output truncated ...]` line between.

The clamp runs at all three points where output is bounded — the streaming reader (`readFor`), the aborted-read buffer (`#preserveAbortedRead`), and the final trim (`truncateOutput`). The first two matter: `readFor` bounds its accumulator to the char budget *before* `truncateOutput` ever sees the data, so without a clamp there the budget trim would already have eaten the head of the long line, including the `dist/main.js.map:1:` prefix that makes the result actionable.

**Truncation markers carry no character counts, deliberately.** Because the streaming reader re-clamps its accumulator on every poll, a count computed at the clamp measures only the chunk in hand: a 200k line arriving in two chunks would report ~100k dropped rather than ~198k. `original_token_count` already reports the true untruncated size, so the counts were both wrong and redundant. Dropping them also removes a fixed-point loop that existed only to keep the marker's own digit count self-consistent.

## Verification

```
pnpm --filter @felan-ai/ext-codex build       # clean
pnpm --filter @felan-ai/ext-codex type-check  # clean
pnpm --filter @felan-ai/ext-codex test        # 54 passed (4 files)
```

Two tests in `test/tools.test.ts` cover the issue's acceptance criteria end to end through `ExecSessionManager.exec` with a real process:

- a 200,000-character `dist/main.js.map` line followed by a short `dist/main.js` hit — asserts a few-KB result, the `.map` line's head (with its filename prefix) present, the clamp marker present, and the short hit preserved;
- 150 KB across 150 lines requested at `Number.MAX_SAFE_INTEGER` tokens — asserts the output is exactly `MAX_OUTPUT_TOKENS * 4` characters, that both the first and last line survive, and that the elision marker sits on its own line.

`README.md` documents the new budget, ceiling, and both markers.

## Out of scope

- Agents polling long builds with `yield_time_ms: 1000`. Same file, different problem, no issue filed.
- Whether Pi's `bash` tool has the same unbounded-line behaviour. Not checked; upstream, and a separate ticket if so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kem9FksKz4Sps213QwnNEj
