### PR TITLE
fix(codebase-memory): avoid stale refresh context

### DIFF
--- a/apps/tui/package.json
+++ b/apps/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felan-ai/felan",
-  "version": "0.20.2",
+  "version": "0.20.3",
   "description": "Open-source, model-portable coding agent built for cost-efficient, verifiable software work",
   "keywords": [
     "ai",

--- a/packages/ext-codebase-memory/package.json
+++ b/packages/ext-codebase-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felan-ai/ext-codebase-memory",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Portable Codebase Memory tools and grep augmentation for Felan",
   "license": "MIT",
   "type": "module",

--- a/packages/ext-codebase-memory/src/index.ts
+++ b/packages/ext-codebase-memory/src/index.ts
@@ -80,7 +80,7 @@ export function createCodebaseMemoryExtension(options: CodebaseMemoryExtensionOp
           );
           return;
         }
-        await refresh(projects, ctx);
+        await refresh(projects, ctx, activeIndexSession);
       },
     });
 
@@ -117,16 +117,36 @@ function detectionMessage(detection: CbmDetection): string {
 
 async function refresh(projects: ProjectService, ctx: ExtensionContext, session?: IndexSession): Promise<void> {
   if (session && !session.active) return;
-  ctx.ui.setStatus('codebase-memory', 'cbm: idx');
+  let signal: AbortSignal | undefined;
   try {
-    await projects.index(ctx.signal);
-    if (session && !session.active) return;
-    ctx.ui.setStatus('codebase-memory', undefined);
+    ctx.ui.setStatus('codebase-memory', 'cbm: idx');
+    signal = ctx.signal;
   } catch (error) {
-    if (session && !session.active) return;
-    ctx.ui.setStatus('codebase-memory', undefined);
-    if (ctx.hasUI) ctx.ui.notify(`Codebase Memory index failed: ${error instanceof Error ? error.message : String(error)}`, 'warning');
+    if (isStaleExtensionContextError(error)) return;
+    throw error;
   }
+  let failed = false;
+  let failure: unknown;
+  try {
+    await projects.index(signal);
+  } catch (error) {
+    failed = true;
+    failure = error;
+  }
+  if (session && !session.active) return;
+  try {
+    ctx.ui.setStatus('codebase-memory', undefined);
+    if (failed && ctx.hasUI) {
+      ctx.ui.notify(`Codebase Memory index failed: ${failure instanceof Error ? failure.message : String(failure)}`, 'warning');
+    }
+  } catch (error) {
+    if (!isStaleExtensionContextError(error)) throw error;
+  }
+}
+
+function isStaleExtensionContextError(error: unknown): boolean {
+  return error instanceof Error
+    && error.message.startsWith('This extension ctx is stale after session replacement or reload.');
 }
 
 const codebaseMemoryExtension = createCodebaseMemoryExtension();

--- a/packages/ext-codebase-memory/test/extension.test.ts
+++ b/packages/ext-codebase-memory/test/extension.test.ts
@@ -186,6 +186,31 @@ describe('Codebase Memory extension', () => {
     ]);
   });
 
+  it('does not reuse a stale command context after refresh indexing completes', async () => {
+    let finishIndexing!: (value: ReturnType<typeof result>) => void;
+    const indexing = new Promise<ReturnType<typeof result>>((resolve) => { finishIndexing = resolve; });
+    let markIndexingStarted!: () => void;
+    const indexingStarted = new Promise<void>((resolve) => { markIndexingStarted = resolve; });
+    const runtime = new MemoryRuntime('host', true, async (command) => {
+      if (command.includes('index_repository')) {
+        markIndexingStarted();
+        return indexing;
+      }
+      if (command.includes('list_projects')) return result(envelope({ projects: [] }));
+      return result(envelope({}));
+    });
+    const harness = await createHarness(runtime);
+
+    const refresh = harness.commandHandlers.get('codebase-memory')?.('', harness.context);
+    await indexingStarted;
+    harness.invalidateContext();
+    finishIndexing(result(envelope({ status: 'indexed', project: 'fixture' })));
+
+    await expect(refresh).resolves.toBeUndefined();
+    expect(harness.statuses).toEqual([['codebase-memory', 'cbm: idx']]);
+    await expect(harness.commandHandlers.get('codebase-memory')?.('', harness.context)).resolves.toBeUndefined();
+  });
+
   it('keeps scoped POSIX coordination below the Darwin Unix socket path limit', () => {
     const longStorageRoot = `/Users/test/${'deeply-nested/'.repeat(20)}agent`;
     const runtimeDirectory = codebaseMemoryRuntimeDirectory(longStorageRoot);
@@ -385,17 +410,26 @@ async function createHarness(
   const commandHandlers = new Map<string, (args: string, ctx: ExtensionContext) => Promise<void> | void>();
   const notifications: Array<[string, string | undefined]> = [];
   const statuses: Array<[string, string | undefined]> = [];
-  const context = {
+  let contextActive = true;
+  const ui = {
+    notify: (message: string, level?: string) => notifications.push([message, level]),
+    setStatus: vi.fn((key: string, text: string | undefined) => statuses.push([key, text])),
+    confirm: vi.fn(async () => false),
+  };
+  const context = Object.defineProperties({
     cwd: runtime.cwd,
-    hasUI: runtime.kind === 'host',
     mode: runtime.kind === 'host' ? 'tui' : 'print',
-    signal: new AbortController().signal,
-    ui: {
-      notify: (message: string, level?: string) => notifications.push([message, level]),
-      setStatus: vi.fn((key: string, text: string | undefined) => statuses.push([key, text])),
-      confirm: vi.fn(async () => false),
-    },
-  } as unknown as ExtensionContext;
+  }, {
+    hasUI: { get: () => activeContextValue(runtime.kind === 'host') },
+    signal: { get: () => activeContextValue(new AbortController().signal) },
+    ui: { get: () => activeContextValue(ui) },
+  }) as unknown as ExtensionContext;
+  function activeContextValue<T>(value: T): T {
+    if (!contextActive) {
+      throw new Error('This extension ctx is stale after session replacement or reload. Do not use a captured ctx.');
+    }
+    return value;
+  }
   const pi = {
     runtime,
     config: {},
@@ -411,6 +445,7 @@ async function createHarness(
   await extension(pi);
   return {
     capabilities, commands, commandHandlers, context, notifications, statuses, tools,
+    invalidateContext: () => { contextActive = false; },
     async emit(name: string, event: Record<string, unknown>): Promise<unknown> {
       let result: unknown;
       for (const handler of handlers.get(name) ?? []) result = await handler(event, context) ?? result;

--- a/packages/ext-codebase-memory/test/package.test.ts
+++ b/packages/ext-codebase-memory/test/package.test.ts
@@ -11,7 +11,7 @@ describe('@felan-ai/ext-codebase-memory package boundary', () => {
     const notice = await readFile(join(packageRoot, 'NOTICE'), 'utf8');
     expect(manifest).toMatchObject({
       name: '@felan-ai/ext-codebase-memory',
-      version: '0.1.3',
+      version: '0.1.4',
       peerDependencies: { '@felan-ai/agent-core': '^0.5.0' },
       publishConfig: { access: 'public', provenance: true },
     });


### PR DESCRIPTION
## Summary

- prevent Codebase Memory refresh completion from accessing a stale extension context after session replacement or reload
- apply the active session guard to command-triggered refreshes
- add regression coverage for context invalidation during an in-flight refresh

## Verification

- `pnpm exec vitest run test/extension.test.ts` (18 passed)
- `pnpm type-check`
- `pnpm exec tsc -p tsconfig.build.json`
- `git diff --check`

The full package test run had one environment-specific existing failure in `test/client.test.ts` (`Error: spawn EFTYPE`) under local Node v24.11.0; this repository requires Node 22.20.0.
